### PR TITLE
CES-9172: introspection fails due to locked node

### DIFF
--- a/src/pilot/introspect_node.py
+++ b/src/pilot/introspect_node.py
@@ -25,7 +25,7 @@ from logging_helper import LoggingHelper
 
 logging.basicConfig()
 logger = logging.getLogger(os.path.splitext(os.path.basename(sys.argv[0]))[0])
-logger.setLevel(logging.DEBUG)
+logger.setLevel(logging.INFO)
 
 
 def parse_arguments():

--- a/src/pilot/ironic_helper.py
+++ b/src/pilot/ironic_helper.py
@@ -48,13 +48,7 @@ class IronicHelper:
                 node = ironic_client.node.get(port.node_uuid)
         elif "." in ip_mac_service_tag:
             # Assume we're looking for the IP address of the iDRAC
-            for n in ironic_client.node.list(
-                fields=[
-                    "driver",
-                    "driver_info",
-                    "uuid",
-                    "properties",
-                    "provision_state"]):
+            for n in ironic_client.node.list(detail=True):
                 drac_ip, _ = CredentialHelper.get_drac_ip_and_user(n)
 
                 if drac_ip == ip_mac_service_tag:
@@ -62,13 +56,7 @@ class IronicHelper:
                     break
         else:
             # Assume we're looking for the service tag
-            for n in ironic_client.node.list(
-                fields=[
-                    "driver",
-                    "driver_info",
-                    "uuid",
-                    "properties",
-                    "provision_state"]):
+            for n in ironic_client.node.list(detail=True):
                 if n.properties["service_tag"] == ip_mac_service_tag:
                     node = n
                     break


### PR DESCRIPTION
This patch changes the introspection logic so that it waits for OOB
introspection to complete before attempting to change the node state to
available.