### PR TITLE
Patch support for NVMe drives into python-dracclient

### DIFF
--- a/src/pilot/dracclient_raid.patch
+++ b/src/pilot/dracclient_raid.patch
@@ -1,6 +1,131 @@
---- /usr/lib/python2.7/site-packages/dracclient/resources/raid.py	2017-10-24 19:12:01.000000000 +0000
-+++ ./raid.py	2017-12-12 22:26:48.964642422 +0000
-@@ -396,13 +396,19 @@
+--- /usr/lib/python2.7/site-packages/dracclient/resources/raid.py	2018-02-09 20:36:18.287726348 +0000
++++ raid.py	2018-02-09 20:35:24.241731242 +0000
+@@ -66,14 +66,17 @@
+     '3': 'fibre',
+     '4': 'usb',
+     '5': 'sata',
+-    '6': 'sas'
++    '6': 'sas',
++    '7': 'pcie',
++    '8': 'nvme'
+ }
+ 
+ PhysicalDiskTuple = collections.namedtuple(
+     'PhysicalDisk',
+     ['id', 'description', 'controller', 'manufacturer', 'model', 'media_type',
+      'interface_type', 'size_mb', 'free_size_mb', 'serial_number',
+-     'firmware_version', 'status', 'raid_status', 'sas_address'])
++     'firmware_version', 'status', 'raid_status', 'sas_address',
++     'device_protocol'])
+ 
+ 
+ class PhysicalDisk(PhysicalDiskTuple):
+@@ -232,7 +235,7 @@
+                                                     nullable=True),
+             controller=fqdd.split(':')[-1],
+             raid_level=REVERSE_RAID_LEVELS[drac_raid_level],
+-            size_mb=int(size_b) / 2 ** 20,
++            size_mb=int(size_b) // 2 ** 20,
+             status=constants.PRIMARY_STATUS[drac_status],
+             raid_status=DISK_RAID_STATUS[drac_raid_status],
+             span_depth=int(self._get_virtual_disk_attr(drac_disk,
+@@ -268,45 +271,74 @@
+         drac_physical_disks = utils.find_xml(doc, 'DCIM_PhysicalDiskView',
+                                              uris.DCIM_PhysicalDiskView,
+                                              find_all=True)
++        physical_disks = [self._parse_drac_physical_disk(disk)
++                          for disk in drac_physical_disks]
+ 
+-        return [self._parse_drac_physical_disk(disk)
+-                for disk in drac_physical_disks]
++        drac_nvme_disks = utils.find_xml(doc, 'DCIM_PCIeSSDView',
++                                         uris.DCIM_PCIeSSDView,
++                                         find_all=True)
++        nvme_disks = [self._parse_drac_physical_disk(disk,
++                      uris.DCIM_PCIeSSDView) for disk in drac_nvme_disks]
++
++        return physical_disks + nvme_disks
++
++    def _parse_drac_physical_disk(self,
++                                  drac_disk,
++                                  uri=uris.DCIM_PhysicalDiskView):
++        fqdd = self._get_physical_disk_attr(drac_disk, 'FQDD', uri)
++        size_b = self._get_physical_disk_attr(drac_disk, 'SizeInBytes', uri)
+ 
+-    def _parse_drac_physical_disk(self, drac_disk):
+-        fqdd = self._get_physical_disk_attr(drac_disk, 'FQDD')
+-        size_b = self._get_physical_disk_attr(drac_disk, 'SizeInBytes')
+         free_size_b = self._get_physical_disk_attr(drac_disk,
+-                                                   'FreeSizeInBytes')
+-        drac_status = self._get_physical_disk_attr(drac_disk, 'PrimaryStatus')
++                                                   'FreeSizeInBytes', uri)
++        if free_size_b is not None:
++            free_size_mb=int(free_size_b) // 2 ** 20
++        else:
++            free_size_mb=None
++
++        drac_status = self._get_physical_disk_attr(drac_disk, 'PrimaryStatus',
++                                                   uri)
+         drac_raid_status = self._get_physical_disk_attr(drac_disk,
+-                                                        'RaidStatus')
+-        drac_media_type = self._get_physical_disk_attr(drac_disk, 'MediaType')
++                                                        'RaidStatus', uri)
++        if drac_raid_status is not None:
++            raid_status = DISK_RAID_STATUS[drac_raid_status]
++        else:
++            raid_status = None
++        drac_media_type = self._get_physical_disk_attr(drac_disk, 'MediaType',
++                                                       uri)
+         drac_bus_protocol = self._get_physical_disk_attr(drac_disk,
+-                                                         'BusProtocol')
++                                                         'BusProtocol', uri)
+ 
+         return PhysicalDisk(
+             id=fqdd,
+             description=self._get_physical_disk_attr(drac_disk,
+-                                                     'DeviceDescription'),
++                                                     'DeviceDescription',
++                                                     uri),
+             controller=fqdd.split(':')[-1],
+             manufacturer=self._get_physical_disk_attr(drac_disk,
+-                                                      'Manufacturer'),
+-            model=self._get_physical_disk_attr(drac_disk, 'Model'),
++                                                      'Manufacturer', uri),
++            model=self._get_physical_disk_attr(drac_disk, 'Model', uri),
+             media_type=PHYSICAL_DISK_MEDIA_TYPE[drac_media_type],
+             interface_type=PHYSICAL_DISK_BUS_PROTOCOL[drac_bus_protocol],
+-            size_mb=int(size_b) / 2 ** 20,
+-            free_size_mb=int(free_size_b) / 2 ** 20,
++            size_mb=int(size_b) // 2 ** 20,
++            free_size_mb=free_size_mb,
+             serial_number=self._get_physical_disk_attr(drac_disk,
+-                                                       'SerialNumber'),
++                                                       'SerialNumber', uri),
+             firmware_version=self._get_physical_disk_attr(drac_disk,
+-                                                          'Revision'),
++                                                          'Revision', uri),
+             status=constants.PRIMARY_STATUS[drac_status],
+-            raid_status=DISK_RAID_STATUS[drac_raid_status],
+-            sas_address=self._get_physical_disk_attr(drac_disk, 'SASAddress'))
++            raid_status=raid_status,
++            sas_address=self._get_physical_disk_attr(drac_disk, 'SASAddress',
++                                                     uri, allow_missing=True),
++            device_protocol=self._get_physical_disk_attr(drac_disk,
++                                                         'DeviceProtocol',
++                                                         uri,
++                                                         allow_missing=True))
+ 
+-    def _get_physical_disk_attr(self, drac_disk, attr_name):
++    def _get_physical_disk_attr(self, drac_disk, attr_name, uri,
++                                allow_missing=False):
+         return utils.get_wsman_resource_attr(
+-            drac_disk, uris.DCIM_PhysicalDiskView, attr_name, nullable=True)
++            drac_disk, uri, attr_name, nullable=True,
++            allow_missing=allow_missing)
+ 
+     def convert_physical_disks(self, physical_disks, raid_enable):
+         """Converts a list of physical disks into or out of RAID mode.
+@@ -396,13 +428,19 @@
              virtual_disk_prop_names.append('VirtualDiskName')
              virtual_disk_prop_values.append(disk_name)
  

--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -236,10 +236,17 @@ sudo rm -f /usr/lib/python2.7/site-packages/dracclient/client.pyc
 sudo rm -f /usr/lib/python2.7/site-packages/dracclient/client.pyo
 echo "## Done."
 
+echo
+echo "## Patching Ironic iDRAC driver uris.py..."
+apply_patch "sudo patch -b -s /usr/lib/python2.7/site-packages/dracclient/resources/uris.py ${HOME}/pilot/uris.patch"
+sudo rm -f /usr/lib/python2.7/site-packages/dracclient/resources/uris.pyc
+sudo rm -f /usr/lib/python2.7/site-packages/dracclient/resources/uris.pyo
+echo "## Done."
+
 # This hacks in a patch to work around a known issue where a RAID-10 virtual
-# disk cannot be created from more than 16 backing physical disks.  Note that
-# this code must be here because we use this code prior to deploying the
-# director.
+# disk cannot be created from more than 16 backing physical disks.  This also
+# patches in support for NVMe drives.  Note that this code must be here because
+# we use this code prior to deploying the director.
 echo
 echo "## Patching Ironic iDRAC driver RAID library..."
 apply_patch "sudo patch -b -s /usr/lib/python2.7/site-packages/dracclient/resources/raid.py ${HOME}/pilot/dracclient_raid.patch"

--- a/src/pilot/uris.patch
+++ b/src/pilot/uris.patch
@@ -1,0 +1,12 @@
+--- /usr/lib/python2.7/site-packages/dracclient/resources/uris.py	2018-02-09 20:36:04.487472252 +0000
++++ uris.py	2018-02-09 20:35:35.961947034 +0000
+@@ -76,6 +76,9 @@
+ DCIM_PhysicalDiskView = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
+                          'DCIM_PhysicalDiskView')
+ 
++DCIM_PCIeSSDView = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
++                    'DCIM_PCIeSSDView')
++
+ DCIM_RAIDService = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
+                     'DCIM_RAIDService')
+ 


### PR DESCRIPTION
This patch adds support for NVMe drives to python-dracclient. A patch has been submitted upstream for this work, so we will need to remove this downstream patch eventually.

See: https://review.openstack.org/#/c/542911/