### PR TITLE
Fixed mistake in bonding options

### DIFF
--- a/src/pilot/templates/nic-configs/4_port/compute.yaml
+++ b/src/pilot/templates/nic-configs/4_port/compute.yaml
@@ -107,7 +107,7 @@ parameters:
     description: Bond 1 interface 2 name
     type: string
   ComputeBondInterfaceOptions:
-    default: '802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1'
+    default: 'mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1'
     description: The bonding_options string for the bond interface.
     type: string
 

--- a/src/pilot/templates/nic-configs/4_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/4_port/controller.yaml
@@ -120,7 +120,7 @@ parameters:
     description: Bond 1 interface 2 name
     type: string
   ControllerBondInterfaceOptions:
-    default: '802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1'
+    default: 'mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1'
     description: The bonding_options string for the bond interface.
     type: string
 

--- a/src/pilot/templates/nic-configs/4_port/nic_environment.yaml
+++ b/src/pilot/templates/nic-configs/4_port/nic_environment.yaml
@@ -26,7 +26,7 @@ parameter_defaults:
   ControllerBond1Interface1: em2
   ControllerBond1Interface2: p1p2
   # The bonding mode to use for controller nodes
-  ControllerBondInterfaceOptions: 802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
+  ControllerBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
   # CHANGEME: Change the interface names in the following lines to include in
   #           the compute nodes bonds
@@ -35,7 +35,7 @@ parameter_defaults:
   ComputeBond1Interface1: em2
   ComputeBond1Interface2: p1p2
   # The bonding mode to use for compute nodes
-  ComputeBondInterfaceOptions: 802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
+  ComputeBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
   # CHANGEME: Change the interface names in the following lines to include in
   #           the storage nodes bonds
@@ -44,4 +44,4 @@ parameter_defaults:
   StorageBond1Interface1: em2
   StorageBond1Interface2: p4p2
   # The bonding mode to use for storage nodes
-  StorageBondInterfaceOptions: 802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
+  StorageBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1

--- a/src/pilot/templates/nic-configs/4_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/4_port/storage.yaml
@@ -111,7 +111,7 @@ parameters:
     description: Bond 1 interface 2 name
     type: string
   StorageBondInterfaceOptions:
-    default: '802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1'
+    default: 'mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1'
     description: The bonding_options string for the bond interface.
     type: string
 

--- a/src/pilot/templates/nic-configs/5_port/compute.yaml
+++ b/src/pilot/templates/nic-configs/5_port/compute.yaml
@@ -111,7 +111,7 @@ parameters:
     description: Bond 1 interface 2 name
     type: string
   ComputeBondInterfaceOptions:
-    default: '802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1'
+    default: 'mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1'
     description: The bonding_options string for the bond interface.
     type: string
 

--- a/src/pilot/templates/nic-configs/5_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/5_port/controller.yaml
@@ -124,7 +124,7 @@ parameters:
     description: Bond 1 interface 2 name
     type: string
   ControllerBondInterfaceOptions:
-    default: '802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1'
+    default: 'mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1'
     description: The bonding_options string for the bond interface.
     type: string
 

--- a/src/pilot/templates/nic-configs/5_port/nic_environment.yaml
+++ b/src/pilot/templates/nic-configs/5_port/nic_environment.yaml
@@ -28,7 +28,7 @@ parameter_defaults:
   ControllerBond1Interface1: em2
   ControllerBond1Interface2: p3p2
   # The bonding mode to use for controller nodes
-  ControllerBondInterfaceOptions: 802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
+  ControllerBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
   # CHANGEME: Change the interface names in the following lines for the
   # compute nodes provisioning interface and to include in the compute
@@ -39,7 +39,7 @@ parameter_defaults:
   ComputeBond1Interface1: em2
   ComputeBond1Interface2: p3p2
   # The bonding mode to use for compute nodes
-  ComputeBondInterfaceOptions: 802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
+  ComputeBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
   # CHANGEME: Change the interface names in the following lines for the
   # storage nodes provisioning interface and to include in the storage
@@ -50,4 +50,4 @@ parameter_defaults:
   StorageBond1Interface1: em2
   StorageBond1Interface2: p2p2
   # The bonding mode to use for storage nodes
-  StorageBondInterfaceOptions: 802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
+  StorageBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1

--- a/src/pilot/templates/nic-configs/5_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/5_port/storage.yaml
@@ -115,7 +115,7 @@ parameters:
     description: Bond 1 interface 2 name
     type: string
   StorageBondInterfaceOptions:
-    default: '802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1'
+    default: 'mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1'
     description: The bonding_options string for the bond interface.
     type: string
 


### PR DESCRIPTION
The bonding mode requires "mode=802.3ad" instead of just "802.3ad".