### PR TITLE
Detecting boss card and select os volume

### DIFF
--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -1094,9 +1094,9 @@ def select_os_volume(os_volume_size_gb, ironic_client, drac_client, node_uuid):
 
             raid_physical_disk_ids = []
 
-            # Look for a RAID of any type other than RAID0 and assume we want to
-            # install the OS on that volume.  The first non-RAID0 found will be
-            # used.
+            # Look for a RAID of any type other than RAID0 and assume we want
+            # to install the OS on that volume.  The first non-RAID0 found
+            # will be used.
             raid_size_gb = 0
             for virtual_disk_doc in virtual_disk_docs:
                 fqdd = get_fqdd(virtual_disk_doc, DCIM_VirtualDiskView)
@@ -1110,17 +1110,18 @@ def select_os_volume(os_volume_size_gb, ironic_client, drac_client, node_uuid):
                     raid_size_gb = int(raid_size) / units.Gi
 
                     # Get the physical disks that back this RAID
-                    raid_physical_disk_docs = utils.find_xml(virtual_disk_doc,
-                                                             'PhysicalDiskIDs',
-                                                             DCIM_VirtualDiskView,
-                                                             True)
+                    raid_physical_disk_docs = utils.find_xml(
+                        virtual_disk_doc,
+                        'PhysicalDiskIDs',
+                        DCIM_VirtualDiskView,
+                        True)
                     for raid_physical_disk_doc in raid_physical_disk_docs:
                         raid_physical_disk_id = raid_physical_disk_doc.text
                         raid_physical_disk_ids.append(raid_physical_disk_id)
 
                     LOG.debug(
-                        "Found RAID {} virtual disk {} with a size of {} bytes "
-                        "comprised of physical disks:\n  {}".format(
+                        "Found RAID {} virtual disk {} with a size of {} "
+                        "bytes comprised of physical disks:\n  {}".format(
                             RAID_TYPE_TO_DESCRIPTION[raid_type],
                             fqdd,
                             raid_size,
@@ -1129,8 +1130,8 @@ def select_os_volume(os_volume_size_gb, ironic_client, drac_client, node_uuid):
                     break
 
             if raid_size_gb == 0:
-                raise RuntimeError("There must be either a virtual disk that is "
-                                   "not a RAID 0 to install the OS on, or "
+                raise RuntimeError("There must be either a virtual disk that "
+                                   "is not a RAID 0 to install the OS on, or "
                                    "os-volume-size-gb must be specified")
 
             # Now check to see if we have any physical disks that don't back
@@ -1152,13 +1153,14 @@ def select_os_volume(os_volume_size_gb, ironic_client, drac_client, node_uuid):
                     physical_disk_size_gb = int(physical_disk_size) / units.Gi
 
                     if physical_disk_size_gb == raid_size_gb:
-                        # If we did find a disk that's the same size as the located
-                        # RAID (in GB), then we can't tell Ironic what volume to
-                        # install the OS on.  Abort the install at this point
-                        # instead of having the OS installed on a random volume.
+                        # If we did find a disk that's the same size as the
+                        # located RAID (in GB), then we can't tell Ironic what
+                        # volume to install the OS on.
+                        # Abort the install at this point instead of having
+                        # the OS installed on a random volume.
                         raise RuntimeError(
-                            "Physical disk {} has the same size in GB ({}) as the "
-                            "RAID.  Unable to specify the OS disk to "
+                            "Physical disk {} has the same size in GB ({}) "
+                            "as the RAID.  Unable to specify the OS disk to "
                             "Ironic.".format(fqdd, physical_disk_size_gb))
 
     if os_volume_size_gb is not None:

--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -850,6 +850,17 @@ def assign_role(ip_mac_service_tag, node_uuid, role_index, os_volume_size_gb,
               'path': '/properties/capabilities'}]
     ironic_client.node.update(node_uuid, patch)
 
+    # Detecting BOSS Card and find the boss device size
+    drac_client = drac_client.client
+    lst_ctrls = drac_client.list_raid_controllers()
+    boss_disk = [ctrl.id for ctrl in lst_ctrls if ctrl.model == "BOSS-S1"]
+    lst_physical_disks = drac_client.list_physical_disks()
+    for disks in lst_physical_disks:
+        if disks.controller in boss_disk:
+            os_volume_size_gb = disks.size_mb/1024
+            LOG.info("Detect BOSS Card {} and volume size {}".format(
+                disks.controller,
+                os_volume_size_gb))
     # Select the volume for the OS to be installed on
     select_os_volume(os_volume_size_gb, ironic_client, drac_client.client,
                      node_uuid)

--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -851,7 +851,6 @@ def assign_role(ip_mac_service_tag, node_uuid, role_index, os_volume_size_gb,
     ironic_client.node.update(node_uuid, patch)
 
     # Detecting BOSS Card and find the boss device size
-    drac_client = drac_client.client
     lst_ctrls = drac_client.list_raid_controllers()
     boss_disk = [ctrl.id for ctrl in lst_ctrls if ctrl.model == "BOSS-S1"]
     lst_physical_disks = drac_client.list_physical_disks()

--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -851,15 +851,18 @@ def assign_role(ip_mac_service_tag, node_uuid, role_index, os_volume_size_gb,
     ironic_client.node.update(node_uuid, patch)
 
     # Detecting BOSS Card and find the boss device size
-    lst_ctrls = drac_client.list_raid_controllers()
-    boss_disk = [ctrl.id for ctrl in lst_ctrls if ctrl.model == "BOSS-S1"]
-    lst_physical_disks = drac_client.list_physical_disks()
-    for disks in lst_physical_disks:
-        if disks.controller in boss_disk:
-            os_volume_size_gb = disks.size_mb/1024
-            LOG.info("Detect BOSS Card {} and volume size {}".format(
-                disks.controller,
-                os_volume_size_gb))
+    if os_volume_size_gb is None:
+        lst_ctrls = drac_client.list_raid_controllers()
+        boss_disk = [ctrl.id for ctrl in lst_ctrls if ctrl.model.startswith("BOSS")]
+        if boss_disk:
+            lst_physical_disks = drac_client.list_physical_disks()
+            for disks in lst_physical_disks:
+                if disks.controller in boss_disk:
+                    os_volume_size_gb = disks.size_mb/1024
+                    LOG.info("Detect BOSS Card {} and volume size {}".format(
+                        disks.controller,
+                        os_volume_size_gb))
+
     # Select the volume for the OS to be installed on
     select_os_volume(os_volume_size_gb, ironic_client, drac_client.client,
                      node_uuid)

--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -850,21 +850,8 @@ def assign_role(ip_mac_service_tag, node_uuid, role_index, os_volume_size_gb,
               'path': '/properties/capabilities'}]
     ironic_client.node.update(node_uuid, patch)
 
-    # Detecting BOSS Card and find the boss device size
-    if os_volume_size_gb is None:
-        lst_ctrls = drac_client.list_raid_controllers()
-        boss_disk = [ctrl.id for ctrl in lst_ctrls if ctrl.model.startswith("BOSS")]
-        if boss_disk:
-            lst_physical_disks = drac_client.list_physical_disks()
-            for disks in lst_physical_disks:
-                if disks.controller in boss_disk:
-                    os_volume_size_gb = disks.size_mb/1024
-                    LOG.info("Detect BOSS Card {} and volume size {}".format(
-                        disks.controller,
-                        os_volume_size_gb))
-
     # Select the volume for the OS to be installed on
-    select_os_volume(os_volume_size_gb, ironic_client, drac_client.client,
+    select_os_volume(os_volume_size_gb, ironic_client, drac_client,
                      node_uuid)
 
     # Generate Ceph OSD/journal configuration for storage nodes
@@ -1084,81 +1071,95 @@ def get_size_in_bytes(doc, namespace):
 
 def select_os_volume(os_volume_size_gb, ironic_client, drac_client, node_uuid):
     if os_volume_size_gb is None:
-        # Get the virtual disks
-        virtual_disk_view_doc = drac_client.enumerate(DCIM_VirtualDiskView)
-        virtual_disk_docs = utils.find_xml(virtual_disk_view_doc,
-                                           'DCIM_VirtualDiskView',
-                                           DCIM_VirtualDiskView,
-                                           True)
+        # Detect BOSS Card and find the volume size
+        lst_ctrls = drac_client.list_raid_controllers()
+        boss_disk = \
+            [ctrl.id for ctrl in lst_ctrls if ctrl.model.startswith("BOSS")]
+        if boss_disk:
+            lst_physical_disks = drac_client.list_physical_disks()
+            for disks in lst_physical_disks:
+                if disks.controller in boss_disk:
+                    os_volume_size_gb = disks.size_mb / 1024
+                    LOG.info("Detect BOSS Card {} and volume size {}".format(
+                        disks.controller,
+                        os_volume_size_gb))
+        else:
+            drac_client = drac_client.client
+            # Get the virtual disks
+            virtual_disk_view_doc = drac_client.enumerate(DCIM_VirtualDiskView)
+            virtual_disk_docs = utils.find_xml(virtual_disk_view_doc,
+                                               'DCIM_VirtualDiskView',
+                                               DCIM_VirtualDiskView,
+                                               True)
 
-        raid_physical_disk_ids = []
+            raid_physical_disk_ids = []
 
-        # Look for a RAID of any type other than RAID0 and assume we want to
-        # install the OS on that volume.  The first non-RAID0 found will be
-        # used.
-        raid_size_gb = 0
-        for virtual_disk_doc in virtual_disk_docs:
-            fqdd = get_fqdd(virtual_disk_doc, DCIM_VirtualDiskView)
-            raid_type = utils.find_xml(virtual_disk_doc, 'RAIDTypes',
-                                       DCIM_VirtualDiskView).text
+            # Look for a RAID of any type other than RAID0 and assume we want to
+            # install the OS on that volume.  The first non-RAID0 found will be
+            # used.
+            raid_size_gb = 0
+            for virtual_disk_doc in virtual_disk_docs:
+                fqdd = get_fqdd(virtual_disk_doc, DCIM_VirtualDiskView)
+                raid_type = utils.find_xml(virtual_disk_doc, 'RAIDTypes',
+                                           DCIM_VirtualDiskView).text
 
-            if raid_type != NORAID and raid_type != RAID0:
-                # Get the size
-                raid_size = get_size_in_bytes(virtual_disk_doc,
-                                              DCIM_VirtualDiskView)
-                raid_size_gb = int(raid_size) / units.Gi
+                if raid_type != NORAID and raid_type != RAID0:
+                    # Get the size
+                    raid_size = get_size_in_bytes(virtual_disk_doc,
+                                                  DCIM_VirtualDiskView)
+                    raid_size_gb = int(raid_size) / units.Gi
 
-                # Get the physical disks that back this RAID
-                raid_physical_disk_docs = utils.find_xml(virtual_disk_doc,
-                                                         'PhysicalDiskIDs',
-                                                         DCIM_VirtualDiskView,
-                                                         True)
-                for raid_physical_disk_doc in raid_physical_disk_docs:
-                    raid_physical_disk_id = raid_physical_disk_doc.text
-                    raid_physical_disk_ids.append(raid_physical_disk_id)
+                    # Get the physical disks that back this RAID
+                    raid_physical_disk_docs = utils.find_xml(virtual_disk_doc,
+                                                             'PhysicalDiskIDs',
+                                                             DCIM_VirtualDiskView,
+                                                             True)
+                    for raid_physical_disk_doc in raid_physical_disk_docs:
+                        raid_physical_disk_id = raid_physical_disk_doc.text
+                        raid_physical_disk_ids.append(raid_physical_disk_id)
 
-                LOG.debug(
-                    "Found RAID {} virtual disk {} with a size of {} bytes "
-                    "comprised of physical disks:\n  {}".format(
-                        RAID_TYPE_TO_DESCRIPTION[raid_type],
-                        fqdd,
-                        raid_size,
-                        "\n  ".join(raid_physical_disk_ids)))
+                    LOG.debug(
+                        "Found RAID {} virtual disk {} with a size of {} bytes "
+                        "comprised of physical disks:\n  {}".format(
+                            RAID_TYPE_TO_DESCRIPTION[raid_type],
+                            fqdd,
+                            raid_size,
+                            "\n  ".join(raid_physical_disk_ids)))
 
-                break
+                    break
 
-        if raid_size_gb == 0:
-            raise RuntimeError("There must be either a virtual disk that is "
-                               "not a RAID 0 to install the OS on, or "
-                               "os-volume-size-gb must be specified")
+            if raid_size_gb == 0:
+                raise RuntimeError("There must be either a virtual disk that is "
+                                   "not a RAID 0 to install the OS on, or "
+                                   "os-volume-size-gb must be specified")
 
-        # Now check to see if we have any physical disks that don't back
-        # the RAID that are the same size as the RAID
+            # Now check to see if we have any physical disks that don't back
+            # the RAID that are the same size as the RAID
 
-        # Get the physical disks
-        physical_disk_view_doc = drac_client.enumerate(
-            DCIM_PhysicalDiskView)
-        physical_disk_docs = utils.find_xml(physical_disk_view_doc,
-                                            'DCIM_PhysicalDiskView',
-                                            DCIM_PhysicalDiskView,
-                                            True)
+            # Get the physical disks
+            physical_disk_view_doc = drac_client.enumerate(
+                DCIM_PhysicalDiskView)
+            physical_disk_docs = utils.find_xml(physical_disk_view_doc,
+                                                'DCIM_PhysicalDiskView',
+                                                DCIM_PhysicalDiskView,
+                                                True)
 
-        for physical_disk_doc in physical_disk_docs:
-            fqdd = get_fqdd(physical_disk_doc, DCIM_PhysicalDiskView)
-            if fqdd not in raid_physical_disk_ids:
-                physical_disk_size = get_size_in_bytes(
-                    physical_disk_doc, DCIM_PhysicalDiskView)
-                physical_disk_size_gb = int(physical_disk_size) / units.Gi
+            for physical_disk_doc in physical_disk_docs:
+                fqdd = get_fqdd(physical_disk_doc, DCIM_PhysicalDiskView)
+                if fqdd not in raid_physical_disk_ids:
+                    physical_disk_size = get_size_in_bytes(
+                        physical_disk_doc, DCIM_PhysicalDiskView)
+                    physical_disk_size_gb = int(physical_disk_size) / units.Gi
 
-                if physical_disk_size_gb == raid_size_gb:
-                    # If we did find a disk that's the same size as the located
-                    # RAID (in GB), then we can't tell Ironic what volume to
-                    # install the OS on.  Abort the install at this point
-                    # instead of having the OS installed on a random volume.
-                    raise RuntimeError(
-                        "Physical disk {} has the same size in GB ({}) as the "
-                        "RAID.  Unable to specify the OS disk to "
-                        "Ironic.".format(fqdd, physical_disk_size_gb))
+                    if physical_disk_size_gb == raid_size_gb:
+                        # If we did find a disk that's the same size as the located
+                        # RAID (in GB), then we can't tell Ironic what volume to
+                        # install the OS on.  Abort the install at this point
+                        # instead of having the OS installed on a random volume.
+                        raise RuntimeError(
+                            "Physical disk {} has the same size in GB ({}) as the "
+                            "RAID.  Unable to specify the OS disk to "
+                            "Ironic.".format(fqdd, physical_disk_size_gb))
 
     if os_volume_size_gb is not None:
         # If os_volume_size_gb was specified then just blindly use that


### PR DESCRIPTION
1. List all the controllers and find boss controller from it
2. Find out the boss card from physical disks using controller model id
4. Calculate the boss card size in GB
5. Pass to select_os_volume method.
6. When we pass the voume size to that method, method directly submit to ironic client