### PR TITLE
Configuring logger to pull out urllib3 warnings

### DIFF
--- a/src/pilot/deploy-overcloud.py
+++ b/src/pilot/deploy-overcloud.py
@@ -664,6 +664,8 @@ def main():
                             help="Indicates if the deploy-overcloud script "
                                  "should be run in debug mode")
         args = parser.parse_args()
+
+        LoggingHelper.configure_logging()
         LoggingHelper.add_argument(parser)
 
         p = re.compile('\d+:\d+')


### PR DESCRIPTION
This is to get rid out the urllib3 warning we have since i changed all print statement to logger statement.
See below.
INFO:requests.packages.urllib3.connectionpool:Starting new HTTP connection (1): 192.168.120.9
