### PR TITLE
Fixed XSP profile deployment failure

### DIFF
--- a/src/pilot/deploy-overcloud.py
+++ b/src/pilot/deploy-overcloud.py
@@ -718,10 +718,9 @@ def main():
         # Edit the dellnfv_environment.yaml
         # If disabled, default values will be set and
         # they won't be used for configuration
-        if args.enable_hugepages or args.enable_numa:
-            edit_dell_environment_file(args.enable_hugepages, args.enable_numa,
-                                       args.hugepages_size, vcpu_pin_set,
-                                       args.num_computes)
+        edit_dell_environment_file(args.enable_hugepages, args.enable_numa,
+                                   args.hugepages_size, vcpu_pin_set,
+                                   args.num_computes)
 
         # Launch the deployment
 


### PR DESCRIPTION
The XSP profile was failing to deploy any compute nodes.  This turned out to be because DellComputeCount in dell-environment.yaml was not being updated.

This patch makes the deployer always update that count regardless of the profile being deployed.