### PR TITLE
Temporary fix to make use_custom_instack work

### DIFF
--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -171,6 +171,9 @@ class Director(InfraHost):
             remote_file = self.home_dir + "/instackenv.json"
             self.upload_file(setts.custom_instack_json,
                              remote_file)
+            cmd = "sudo chown " + setts.director_install_account_user + ":" + \
+                setts.director_install_account_user + " " + remote_file
+            self.run_tty(cmd)
         else:
 
             # In 13g servers, the iDRAC sends out a DHCP req every 3 seconds


### PR DESCRIPTION
Currently use_custom_instack doesn't work because the instackenv.json is
copied to the director node as root.  config_idrac then tries to edit the
file and that fails because the director user does not own the file.

This is a temporary fix to change ownership of the file to the director user.