### PR TITLE
Fix deployment failure due to invalid characters from iDRAC

### DIFF
--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -251,6 +251,14 @@ sudo rm -f /usr/lib/python2.7/site-packages/dracclient/resources/uris.pyc
 sudo rm -f /usr/lib/python2.7/site-packages/dracclient/resources/uris.pyo
 echo "## Done."
 
+# This hacks in a patch to work around an issue where the iDRAC can return
+# invalid non-ASCII characters during an enumeration.
+echo
+echo "## Patching Ironic iDRAC driver wsman.py..."
+apply_patch "sudo patch -b -s /usr/lib/python2.7/site-packages/dracclient/wsman.py ${HOME}/pilot/wsman.patch"
+sudo rm -f /usr/lib/python2.7/site-packages/dracclient/wsman.pyc
+sudo rm -f /usr/lib/python2.7/site-packages/dracclient/wsman.pyo
+
 # This hacks in a patch to work around a known issue where a RAID-10 virtual
 # disk cannot be created from more than 16 backing physical disks.  This also
 # patches in support for NVMe drives.  Note that this code must be here because

--- a/src/pilot/wsman.patch
+++ b/src/pilot/wsman.patch
@@ -1,0 +1,26 @@
+--- /usr/lib/python2.7/site-packages/dracclient/wsman.py	2018-04-09 14:38:16.276668011 +0000
++++ wsman.py	2018-04-09 14:37:53.173252503 +0000
+@@ -12,6 +12,7 @@
+ #    under the License.
+ 
+ import logging
++import re
+ import time
+ import uuid
+ 
+@@ -157,7 +158,14 @@
+                                     filter_query, filter_dialect)
+ 
+         resp = self._do_request(payload)
+-        resp_xml = ElementTree.fromstring(resp.content)
++
++        try:
++            resp_xml = ElementTree.fromstring(resp.content)
++        except ElementTree.XMLSyntaxError:
++            LOG.warning('Received invalid content from iDRAC.  Filtering out '
++                        'non-ASCII characters: ' + resp.content)
++            LOG.exception('Exception: ')
++            resp_xml = ElementTree.fromstring(re.sub(r'[^\x00-\x7f]',r'', resp.content))
+ 
+         if auto_pull:
+             # The first response returns "<wsman:Items>"


### PR DESCRIPTION
This patch fixes an issue where on some stamps, when enumerating
DCIM_ControllerView, the iDRAC can return invalid unprintable
characters in the DriverVersion field.

This patch catches an XMLSyntaxError generated by etree.fromstring() during
enumeration and when it occurs, it strips out the unprintable characters and
reparses the XML in addition to logging the offending XML and the exception.