### PR TITLE
Changing dpdk_enable enforcement for CSP Profile

### DIFF
--- a/src/deploy/osp_deployer/profiles/csp.json
+++ b/src/deploy/osp_deployer/profiles/csp.json
@@ -20,7 +20,12 @@
 			"8"
 		]
 	    },
-            "ovs_dpdk_enable": ""
+            "ovs_dpdk_enable": {
+                "valid_values": [
+                   "true",
+                   "false"
+                ]
+            }
          }
       },
       {


### PR DESCRIPTION
This fix allows the user to set dpdk to disable even if he's using a csp profile. It reduces enforcement but allows flexibility. Hopefully solving the bug Kurt went through.