### PR TITLE
Removed os_volume_size_gb from storage nodes

### DIFF
--- a/src/deploy/osp_deployer/settings/sample.properties
+++ b/src/deploy/osp_deployer/settings/sample.properties
@@ -97,8 +97,6 @@
         "is_ceph_storage": "true",
         "idrac_ip": "192.168.110.76",
 
-        "os_volume_size_gb": "223",
-
         "storage_ip": "192.168.170.76",
         "storage_cluster_ip": "192.168.180.76"
     },
@@ -106,16 +104,12 @@
         "is_ceph_storage": "true",
         "service_tag": "GHIRST",
 
-        "os_volume_size_gb": "223",
-
         "storage_ip": "192.168.170.77",
         "storage_cluster_ip": "192.168.180.77"
     },
     {
         "is_ceph_storage": "true",
         "idrac_ip": "192.168.110.78",
-
-        "os_volume_size_gb": "223",
 
         "storage_ip": "192.168.170.78",
         "storage_cluster_ip": "192.168.180.78"


### PR DESCRIPTION
With the BOSS card enhancements, os_volume_size_gb is no longer needed in the .properties file.