### PR TITLE
Replaced "&" with "and" so copying and pasting into docs works

### DIFF
--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -14,7 +14,7 @@
 
 ######################################################################################
 #                                                                                    #
-#        Copy & rename this file for your own stamp.                                 #
+#        Copy and rename this file for your own stamp.                                 #
 #        Review ALL settings below, pay particular attention to paths/ip's etc..     #
 #                                                                                    #
 ######################################################################################

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -14,7 +14,7 @@
 
 ######################################################################################
 #                                                                                    #
-#        Copy & rename this file for your own stamp.                                 #
+#        Copy and rename this file for your own stamp.                                 #
 #        Review ALL settings below, pay particular attention to paths/ip's etc..     #
 #                                                                                    #
 ######################################################################################


### PR DESCRIPTION
Replaced "&" with "and" so copying and pasting these files into the docs sample files does not cause a docs explosion.