### PR TITLE
Change min value for maraidb_max_connection and innodb_buffer_pool_instances

### DIFF
--- a/src/deploy/osp_deployer/profiles/csp.json
+++ b/src/deploy/osp_deployer/profiles/csp.json
@@ -43,7 +43,7 @@
                   "should_be_valid_int"
                ],
                "in_range": [
-                  "1-48"
+                  "8-48"
                ]
             },
             "innodb_buffer_pool_size": {
@@ -56,7 +56,7 @@
                   "should_be_valid_int"
                ],
                "in_range": [
-                  "1-100000"
+                  "151-100000"
                ]
 	    }
          }

--- a/src/deploy/osp_deployer/profiles/xsp.json
+++ b/src/deploy/osp_deployer/profiles/xsp.json
@@ -40,7 +40,7 @@
                   "should_be_valid_int"
                ],
                "in_range": [
-                  "1-48"
+                  "8-48"
                ]
             },
             "innodb_buffer_pool_size": {
@@ -53,7 +53,7 @@
                   "should_be_valid_int"
                ],
                "in_range": [
-                  "1-100000"
+                  "151-100000"
                ]
             }
          }

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -213,7 +213,7 @@ numa_hostos_cpu_count=4
 
 [Performance and Optimization]
 
-# mariadb_max_connections takes value from 1 to 100000, it is mandatory.
+# mariadb_max_connections takes value from 151 to 100000, it is mandatory.
 mariadb_max_connections = 15360
 
 # MariaDB innodb_buffer_pool_size should be given value in GB, Example : 64G.
@@ -221,7 +221,7 @@ mariadb_max_connections = 15360
 # Note that innodb_buffer_pool_size should be less than available ram size.
 innodb_buffer_pool_size = dynamic
 
-# innodb_buffer_pool_instances takes value from 1 to 48
+# innodb_buffer_pool_instances takes value from 8 to 48
 innodb_buffer_pool_instances = 16
 
 [IPMI credentials Settings]

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -212,7 +212,7 @@ numa_hostos_cpu_count=4
 
 [Performance and Optimization]
 
-# mariadb_max_connections takes value from 1 to 100000, it is mandatory.
+# mariadb_max_connections takes value from 151 to 100000, it is mandatory.
 mariadb_max_connections = 15360
 
 # MariaDB innodb_buffer_pool_size should be given value in GB, Example : 64G.
@@ -220,7 +220,7 @@ mariadb_max_connections = 15360
 # Note that innodb_buffer_pool_size should be less than available ram size.
 innodb_buffer_pool_size = dynamic
 
-# innodb_buffer_pool_instances takes value from 1 to 48
+# innodb_buffer_pool_instances takes value from 8 to 48
 innodb_buffer_pool_instances = 16
 
 [IPMI credentials Settings]


### PR DESCRIPTION
- Added min value for mariadb_max_connection to 151 which is default in mariadb
- Changes min value for innodb_buffer_pool_instances to 8 which is also default