### PR TITLE
Deployment fails with ManilaBackendGeneric error

### DIFF
--- a/src/pilot/templates/roles_data.yaml
+++ b/src/pilot/templates/roles_data.yaml
@@ -90,7 +90,7 @@
     - OS::TripleO::Services::GnocchiStatsd
     - OS::TripleO::Services::ManilaApi
     - OS::TripleO::Services::ManilaScheduler
-    - OS::TripleO::Services::ManilaBackendGeneric
+    #- OS::TripleO::Services::ManilaBackendGeneric
     - OS::TripleO::Services::ManilaBackendNetapp
     - OS::TripleO::Services::ManilaBackendCephFs
     - OS::TripleO::Services::ManilaShare


### PR DESCRIPTION
This patch comments out inclusion of the ManilaBackendGeneric service
as this service was removed in the latest OSP10 bits.