### PR TITLE
Add support for DSS9000

### DIFF
--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -881,14 +881,18 @@ def generate_osd_config(ip_mac_service_tag, drac_client):
     controllers = drac_client.list_raid_controllers()
 
     found_hba = False
+    found_boss = False
     for controller in controllers:
         if "hba330" in controller.model.lower():
             found_hba = True
-            break
+        if "boss" in controller.model.lower():
+            found_boss = True
 
-    if not found_hba:
-        LOG.info("No HBA330 found.  Not generating OSD config for "
-                 "{ip}".format(ip=ip_mac_service_tag))
+    if not (found_hba and found_boss):
+        LOG.info("Both BOSS and HBA330 must be present for automatic OSD "
+                 "configuration. Not generating OSD config for {ip} because "
+                 "one, or the other, or both are not present.".format(
+                     ip=ip_mac_service_tag))
         return
 
     LOG.info("Generating OSD config for {ip}".format(ip=ip_mac_service_tag))

--- a/src/pilot/dell_systems.json
+++ b/src/pilot/dell_systems.json
@@ -31,5 +31,11 @@
   },
   "PowerEdge R640": {
     "pxe_nic": "NIC.Integrated.1-3-1"
+  },
+  "DSS 9600": {
+    "pxe_nic": "NIC.Mezzanine.3-1-1"
+  },
+  "DSS 9620": {
+    "pxe_nic": "NIC.Mezzanine.3-1-1"
   }
 }


### PR DESCRIPTION
- This patch adds support for the DSS9000 by adding a NIC entry to
  dell_systems.json.
- It also adds support for storage nodes that only have an HBA330 and no BOSS
  card since this is the way that the DSS9000 storage nodes were configured.