### PR TITLE
Only require HBA330 to be present for auto OSD config generation

### DIFF
--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -881,18 +881,14 @@ def generate_osd_config(ip_mac_service_tag, drac_client):
     controllers = drac_client.list_raid_controllers()
 
     found_hba = False
-    found_boss = False
     for controller in controllers:
         if "hba330" in controller.model.lower():
             found_hba = True
-        if "boss" in controller.model.lower():
-            found_boss = True
+            break
 
-    if not (found_hba and found_boss):
-        LOG.info("Both BOSS and HBA330 must be present for automatic OSD "
-                 "configuration. Not generating OSD config for {ip} because "
-                 "one, or the other, or both are not present.".format(
-                     ip=ip_mac_service_tag))
+    if not found_hba:
+        LOG.info("Not generating OSD config for {ip} because no HBA330 is "
+                 "present.".format(ip=ip_mac_service_tag))
         return
 
     LOG.info("Generating OSD config for {ip}".format(ip=ip_mac_service_tag))


### PR DESCRIPTION
The DSS9k nodes did not have BOSS cards, only HBA330s.  This change makes it so that only an HBA330 needs to be present for assign_role to auto generate the Ceph OSD configuration.