### PR TITLE
Increased iDRAC is-ready retries to 96

### DIFF
--- a/src/pilot/constants.patch
+++ b/src/pilot/constants.patch
@@ -1,0 +1,11 @@
+--- /usr/lib/python2.7/site-packages/dracclient/constants.py	2018-02-19 12:01:19.000000000 +0000
++++ constants.py	2018-08-16 19:21:12.446870000 +0000
+@@ -12,7 +12,7 @@
+ #    under the License.
+ 
+ # iDRAC is ready retry constants
+-DEFAULT_IDRAC_IS_READY_RETRIES = 48
++DEFAULT_IDRAC_IS_READY_RETRIES = 96
+ DEFAULT_IDRAC_IS_READY_RETRY_DELAY_SEC = 10
+ 
+ # Web Services Management (WS-Management and WS-Man) SSL retry on error

--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -245,6 +245,14 @@ echo "source ~/stackrc" >> ~/.bash_profile
 echo "## Done."
 
 
+# This hacks in a patch to increase the number of iDRAC is-ready retries to 96,
+# which is required for the latest firmware.
+echo
+echo "## Patching Ironic iDRAC driver constants.py..."
+apply_patch "sudo patch -b -s /usr/lib/python2.7/site-packages/dracclient/constants.py ${HOME}/pilot/constants.patch"
+sudo rm -f /usr/lib/python2.7/site-packages/dracclient/constants.pyc
+sudo rm -f /usr/lib/python2.7/site-packages/dracclient/constants.pyo
+
 # This hacks in a patch to work around an issue where the iDRAC can return
 # invalid non-ASCII characters during an enumeration.
 echo


### PR DESCRIPTION
Increased iDRAC is-ready retries to 96, which is required for the latest firmware.