### PR TITLE
CES-9801 - Helper functions to determine boot mode, BIOS or UEFI

### DIFF
--- a/boot_mode_helper.py
+++ b/boot_mode_helper.py
@@ -1,0 +1,55 @@
+#!/usr/bin/python
+
+# Copyright (c) 2016-2018 Dell Inc. or its subsidiaries.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+import os
+import sys
+
+from ironic.common import boot_devices
+
+DRAC_BOOT_MODE_BIOS = 'Bios'
+DRAC_BOOT_MODE_UEFI = 'Uefi'
+
+# TODO(Update Ironic Boot Modes)
+"""For Rocky release, boot modes are defined in boot_modes.py file,
+When we upgrade to next version, we need to import ironic boot modes
+instead of [boot_devices.BIOS and uefi]."""
+DRAC_BOOT_MODES = {
+    DRAC_BOOT_MODE_BIOS: boot_devices.BIOS,
+    DRAC_BOOT_MODE_UEFI: "uefi"
+}
+
+IRONIC_BOOT_MODES = dict((v, k) for (k, v) in DRAC_BOOT_MODES.items())
+
+
+class BootModeHelper(object):
+    path = os.path.basename(sys.argv[0])[0]
+    LOG = logging.getLogger(os.path.splitext(path)[0])
+
+    @staticmethod
+    def is_boot_order_flexibly_programmable(drac_client, bios_settings=None):
+        if not bios_settings:
+            bios_settings = drac_client.list_bios_settings()
+        return 'SetBootOrderFqdd1' in bios_settings
+
+    @staticmethod
+    def determine_boot_mode(drac_client, bios_settings=None):
+        if not bios_settings:
+            bios_settings = drac_client.list_bios_settings(by_name=True)
+        if is_boot_order_flexibly_programmable(drac_client, bios_settings):
+            drac_boot_mode = bios_settings['BootMode'].current_value
+
+            return drac_boot_mode

--- a/src/pilot/boot_mode_helper.py
+++ b/src/pilot/boot_mode_helper.py
@@ -19,13 +19,13 @@ from ironic.drivers.modules import deploy_utils
 DRAC_BOOT_MODE_BIOS = 'Bios'
 DRAC_BOOT_MODE_UEFI = 'Uefi'
 
-DRAC_TO_IRONIC_BOOT_MODES = {
+DRAC_BOOT_MODE_TO_IRONIC_BOOT_MODE_CAP = {
     DRAC_BOOT_MODE_BIOS: deploy_utils.SUPPORTED_CAPABILITIES['boot_mode'][0],
     DRAC_BOOT_MODE_UEFI: deploy_utils.SUPPORTED_CAPABILITIES['boot_mode'][1]
 }
 
-IRONIC_TO_DRAC_BOOT_MODES = \
-    dict((v, k) for (k, v) in DRAC_TO_IRONIC_BOOT_MODES.items())
+IRONIC_BOOT_MODE_CAP_TO_DRAC_BOOT_MODE = \
+    dict((v, k) for (k, v) in DRAC_BOOT_MODE_TO_IRONIC_BOOT_MODE_CAP.items())
 
 
 class BootModeHelper(object):

--- a/src/pilot/boot_mode_helper.py
+++ b/src/pilot/boot_mode_helper.py
@@ -40,5 +40,4 @@ class BootModeHelper(object):
     def get_boot_mode(drac_client, bios_settings=None):
         if not bios_settings:
             bios_settings = drac_client.list_bios_settings(by_name=True)
-        if is_boot_order_flexibly_programmable(drac_client, bios_settings):
-            return bios_settings['BootMode'].current_value
+        return bios_settings['BootMode'].current_value

--- a/src/pilot/boot_mode_helper.py
+++ b/src/pilot/boot_mode_helper.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python
 
-# Copyright (c) 2016-2018 Dell Inc. or its subsidiaries.
+# Copyright (c) 2018 Dell Inc. or its subsidiaries.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -14,42 +14,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import logging
-import os
-import sys
-
-from ironic.common import boot_devices
+from ironic.drivers.modules import deploy_utils
 
 DRAC_BOOT_MODE_BIOS = 'Bios'
 DRAC_BOOT_MODE_UEFI = 'Uefi'
 
-# TODO(Update Ironic Boot Modes)
-"""For Rocky release, boot modes are defined in boot_modes.py file,
-When we upgrade to next version, we need to import ironic boot modes
-instead of [boot_devices.BIOS and uefi]."""
-DRAC_BOOT_MODES = {
-    DRAC_BOOT_MODE_BIOS: boot_devices.BIOS,
-    DRAC_BOOT_MODE_UEFI: "uefi"
+DRAC_TO_IRONIC_BOOT_MODES = {
+    DRAC_BOOT_MODE_BIOS: deploy_utils.SUPPORTED_CAPABILITIES['boot_mode'][0],
+    DRAC_BOOT_MODE_UEFI: deploy_utils.SUPPORTED_CAPABILITIES['boot_mode'][1]
 }
 
-IRONIC_BOOT_MODES = dict((v, k) for (k, v) in DRAC_BOOT_MODES.items())
+IRONIC_TO_DRAC_BOOT_MODES = \
+    dict((v, k) for (k, v) in DRAC_TO_IRONIC_BOOT_MODES.items())
 
 
 class BootModeHelper(object):
-    path = os.path.basename(sys.argv[0])[0]
-    LOG = logging.getLogger(os.path.splitext(path)[0])
 
     @staticmethod
     def is_boot_order_flexibly_programmable(drac_client, bios_settings=None):
         if not bios_settings:
-            bios_settings = drac_client.list_bios_settings()
+            bios_settings = drac_client.list_bios_settings(by_name=True)
         return 'SetBootOrderFqdd1' in bios_settings
 
     @staticmethod
-    def determine_boot_mode(drac_client, bios_settings=None):
+    def get_boot_mode(drac_client, bios_settings=None):
         if not bios_settings:
             bios_settings = drac_client.list_bios_settings(by_name=True)
         if is_boot_order_flexibly_programmable(drac_client, bios_settings):
-            drac_boot_mode = bios_settings['BootMode'].current_value
-
-            return drac_boot_mode
+            return bios_settings['BootMode'].current_value


### PR DESCRIPTION
Below tasks are implemented -
 

1.  Determine current boot mode
2.  Check is_boot_order_flexibly_programmable() method
3. Define dictionary to change the boot order from drac to ironic and vice-versa