### PR TITLE
removing ceph workaround

### DIFF
--- a/src/pilot/customize_image.sh
+++ b/src/pilot/customize_image.sh
@@ -89,9 +89,6 @@ cd ~/pilot/images
 
 run_command "virt-customize -a overcloud-full.qcow2 --run-command \"echo '${director_ip} ${director_short} ${director_long}' >> /etc/hosts\""
 
-#Temporary fix for Ceph-OSD not starting (BZ#1472409)
-run_command "virt-customize -a overcloud-full.qcow2 --run-command 'sed -i \"s/timeout 120/timeout 10000/\" /usr/lib/systemd/system/ceph-disk\@.service'"
-
 run_command "virt-customize \
     --memsize 2000 \
     --add overcloud-full.qcow2 \


### PR DESCRIPTION
.. for BZ 1472409
Ceph is now containerized / that file is gone from latest overcloud image coming in next ZStream