### PR TITLE
Changed threads to match upstream fix

### DIFF
--- a/src/pilot/wsgi.patch
+++ b/src/pilot/wsgi.patch
@@ -5,7 +5,7 @@
    SetEnvIf X-Forwarded-Proto https HTTPS=1
    WSGIApplicationGroup %{GLOBAL}
 -  WSGIDaemonProcess ironic display-name=ironic_wsgi group=ironic processes=4 threads=1 user=ironic
-+  WSGIDaemonProcess ironic display-name=ironic_wsgi group=ironic processes=8 threads=1 user=ironic
++  WSGIDaemonProcess ironic display-name=ironic_wsgi group=ironic processes=4 threads=15 user=ironic
    WSGIProcessGroup ironic
    WSGIScriptAlias / "/var/www/cgi-bin/ironic/app"
  </VirtualHost>


### PR DESCRIPTION
The upstream fix for the http 500 issue is 4 processes * 15 threads, for a total of 60 threads.

This PR changes the patch to match that, which addresses 500 errors on 13G stamps.