### PR TITLE
SR-IOV changes 

### DIFF
--- a/src/deploy/osp_deployer/profiles/csp.json
+++ b/src/deploy/osp_deployer/profiles/csp.json
@@ -176,8 +176,8 @@
                   "5_port/nic_environment.yaml",
                   "ovs-dpdk_9_port/nic_environment.yaml",
                   "ovs-dpdk_7_port/nic_environment.yaml",
-                  "sriov_9_ports/nic_environment.yaml",
-                  "sriov_7_ports/nic_environment.yaml",
+                  "sriov_9_port/nic_environment.yaml",
+                  "sriov_7_port/nic_environment.yaml",
                   "dvr_6_port/nic_environment.yaml",
                   "dvr_7_port/nic_environment.yaml"
                ]

--- a/src/deploy/osp_deployer/profiles/xsp.json
+++ b/src/deploy/osp_deployer/profiles/xsp.json
@@ -171,8 +171,8 @@
                "valid_values": [
                   "4_port/nic_environment.yaml",
                   "5_port/nic_environment.yaml",
-                  "sriov_9_ports/nic_environment.yaml",
-                  "sriov_7_ports/nic_environment.yaml",
+                  "sriov_9_port/nic_environment.yaml",
+                  "sriov_7_port/nic_environment.yaml",
                   "dvr_6_port/nic_environment.yaml",
                   "dvr_7_port/nic_environment.yaml"
                ]

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -82,10 +82,11 @@ tenant_vlan_range=201:250
 
 
 [MTU Settings]
-# The mtu_selection setting defines whether to use the "global" or "per_network" option. If the mtu_selection is defined as "global", the mtu value for all networks will be set to the value provided in mtu_size_global_default. The supported value must be within the range of 1500-9000. If the "per_network"  is defined, the user should provide an mtu value for each network in the range of 1500-9000.
-# For "public_api_network_mtu"  and  "floating_ip_network_mtu" networks, mtu sizes greater than 1500 is only supported if jumbo frames are enabled on upstream routers.
 
-# global | per_network
+# The mtu_selection setting defines whether to use the "global" or "per_network" option. 
+# If the mtu_selection is defined as "global", the mtu value for all networks will be set to the value provided in mtu_size_global_default. The supported value must be within the range of 1500-9000.
+# If "per_network" mtu_selection is defined, the user should provide an mtu value for each network in the range of 1500-9000.
+# For "public_api_network_mtu" and "floating_ip_network_mtu" networks, mtu sizes greater than 1500 is only supported if jumbo frames are enabled on upstream routers.
 mtu_selection=global 
 mtu_size_global_default=1500
 public_api_network_mtu=1500
@@ -160,17 +161,15 @@ subscription_check_retries=20
 sah_bond_opts=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
 # NIC environment file
-# Note: If using Mellanox 25 gig NICs, change the following to:
-#       4_port/nic_environment.yaml
-#       If you need to enable OVS-DPDK, then use
-#       ovs-dpdk_X_port as nic home directory
-#       where X represents the total number of ports:
-#            9: Five + Four DPDK ports
-#            7: Five + Two DPDK ports
-#       If SR-IOV needs to enable, then use
-#       sriov_9_port or sriov_7_port as nic home directory
-#            9: Five + Four SRIOV ports
-#            7: Five + Two SRIOV ports
+#       1. To enable standard XSP profile or standard CSP profile (NUMA and HugePages):
+#          For 5 ports, choose 5_port/nic_environment.yaml. 
+#          For 4 ports, choose 4_port/nic_environment.yaml
+#To enable OVS-DPDK with 7 nic ports, choose ovs-dpdk_7_port/nic_environment.yaml.
+#          For 9 ports, choose ovs-dpdk_9_port/nic_enviornment.yaml
+#       2. To enable SR-IOV with 7 nic ports, choose sriov_7_port/nic_environment.yaml.
+#          For 9 ports, choose sriov_9_port/nic_enviornment.yaml
+#       3. To enable DVR, for Storage and Floating networks that share a single bond, choose 5_port/nic_environment.yaml.
+#          If a separate bond is required for Floating network on compute nodes, choose dvr_7_port/nic_environment.yaml
 nic_env_file=5_port/nic_environment.yaml
 
 # Interfaces and bonding options per node type.
@@ -201,10 +200,8 @@ StorageBond1Interface1=em2
 StorageBond1Interface2=p2p2
 StorageBondInterfaceOptions=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
-# Note: the following interfaces need to be changed
-# as per the server model
-# R640 should use 'p2p1', 'p3p1', 'p2p2', 'p3p2'
-# R740/R740xd should use 'p4p1', 'p5p1', 'p4p2', 'p5p2'
+# To enable standalone OVS-DPDK, two or four interfaces should be used.
+# To enable OVS-DPDK with SR-IOV, two interfaces should be used.
 # The following lines should be commented out  if ovs_dpdk_enable is set to false
 #ComputeOvsDpdkInterface1=p2p1
 #ComputeOvsDpdkInterface2=p3p1
@@ -212,9 +209,8 @@ StorageBondInterfaceOptions=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 la
 #ComputeOvsDpdkInterface4=p3p2
 #BondInterfaceOvsOptions=bond_mode=balance-tcp lacp=active
 
-# Note: the following interfaces need to be changed as per the server model
-# To enable standalone SR-IOV, two or four interfaces should be used
-# For enabling SR-IOV with OVS-DPDK, two interfaces should be used.
+# To enable standalone SR-IOV, two or four interfaces should be used.
+# To enable SR-IOV with OVS-DPDK, two interfaces should be used.
 # Following lines should be commented out if sriov_enable is set to false
 #ComputeSriovInterface1=p1p1
 #ComputeSriovInterface2=p4p1
@@ -222,7 +218,6 @@ StorageBondInterfaceOptions=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 la
 #ComputeSriovInterface4=p4p2
 
 [Dell NFV Settings]
-#Provide NFV features here.
 
 #Enter value of enable_hpg as true/false for HugePages
 hpg_enable=true
@@ -239,7 +234,7 @@ numa_enable=true
 ovs_dpdk_enable=false
 
 # Enter number of cores you want to reserve for Host OS
-# Supported values are 2 or 4 or 6 or 8
+# Supported values are 2,4,6,8
 numa_hostos_cpu_count=4
 
 # SRIOV Settings
@@ -250,13 +245,7 @@ sriov_enable=false
 # Supported values are between 1-64
 sriov_vf_count=64
 
-# Set to True to enable DVR
-# Note: DVR requires different NIC configuration
-# Change nic_env_file path accordingly
-# Storage and Floating networks share a single bond when nic_env_file parameter
-# is set to default value of either 5_port/nic_environment.yaml.
-# If a separate bond is required for Floating network on compute nodes, set the nic_env_file
-# parameter to dvr_7_port/nic_environment.yaml
+# Set to true to enable DVR
 dvr_enable=false
 
 
@@ -327,8 +316,6 @@ enable_rbd_backend=true
 enable_rbd_nova_backend=true
 
 # Set to false to disable fencing
-# Please refer to the following document for more details on fencing:
-# Dell EMC NFV Ready Bundle for Red Hat Software Deployment Guide
 enable_fencing=true
 
 [Storage back-end Settings]

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -167,6 +167,10 @@ sah_bond_opts=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 #       where X represents the total number of ports:
 #            9: Five + Four DPDK ports
 #            7: Five + Two DPDK ports
+#       If SR-IOV needs to enable, then use
+#       sriov_9_port or sriov_7_port as nic home directory
+#            9: Five + Four SRIOV ports
+#            7: Five + Two SRIOV ports
 nic_env_file=5_port/nic_environment.yaml
 
 # Interfaces and bonding options per node type.
@@ -209,7 +213,7 @@ StorageBondInterfaceOptions=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 la
 #BondInterfaceOvsOptions=bond_mode=balance-tcp lacp=active
 
 # Note: the following interfaces need to be changed as per the server model
-# TO enable standalone SR-IOV, two or four interfaces should be used
+# To enable standalone SR-IOV, two or four interfaces should be used
 # For enabling SR-IOV with OVS-DPDK, two interfaces should be used.
 # Following lines should be commented out if sriov_enable is set to false
 #ComputeSriovInterface1=p1p1
@@ -244,7 +248,7 @@ sriov_enable=false
 
 # Enter the number of VFs you want to create per port
 # Supported values are between 1-64
-sriov_vf_count=5
+sriov_vf_count=64
 
 # Set to True to enable DVR
 # Note: DVR requires different NIC configuration

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -164,11 +164,12 @@ sah_bond_opts=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 #       1. To enable standard XSP profile or standard CSP profile (NUMA and HugePages):
 #          For 5 ports, choose 5_port/nic_environment.yaml. 
 #          For 4 ports, choose 4_port/nic_environment.yaml
-#To enable OVS-DPDK with 7 nic ports, choose ovs-dpdk_7_port/nic_environment.yaml.
+#       2. To enable OVS-DPDK with 7 nic ports, choose ovs-dpdk_7_port/nic_environment.yaml.
 #          For 9 ports, choose ovs-dpdk_9_port/nic_enviornment.yaml
-#       2. To enable SR-IOV with 7 nic ports, choose sriov_7_port/nic_environment.yaml.
+#       3. To enable SR-IOV with 7 nic ports, choose sriov_7_port/nic_environment.yaml.
 #          For 9 ports, choose sriov_9_port/nic_enviornment.yaml
-#       3. To enable DVR, for Storage and Floating networks that share a single bond, choose 5_port/nic_environment.yaml.
+#       4. To enable OVS-DPDK (2-ports) and SR-IOV (2-ports),choose ovs-dpdk_sriov_9_port/nic_environment.yaml
+#       5. To enable DVR, for Storage and Floating networks that share a single bond, choose 5_port/nic_environment.yaml.
 #          If a separate bond is required for Floating network on compute nodes, choose dvr_7_port/nic_environment.yaml
 nic_env_file=5_port/nic_environment.yaml
 

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -167,6 +167,10 @@ sah_bond_opts=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 #       where X represents the total number of ports:
 #            9: Five + Four DPDK ports
 #            7: Five + Two DPDK ports
+#       If SR-IOV needs to enable, then use
+#       sriov_9_port or sriov_7_port as nic home directory
+#            9: Five + Four SRIOV ports
+#            7: Five + Two SRIOV ports
 nic_env_file=5_port/nic_environment.yaml
 
 # Interfaces and bonding options per node type.
@@ -209,7 +213,7 @@ StorageBondInterfaceOptions=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 la
 #BondInterfaceOvsOptions=bond_mode=balance-tcp lacp=active
 
 # Note: the following interfaces need to be changed as per the server model
-# TO enable standalone SR-IOV, two or four interfaces should be used
+# To enable standalone SR-IOV, two or four interfaces should be used
 # For enabling SR-IOV with OVS-DPDK, two interfaces should be used.
 # Following lines should be commented out if sriov_enable is set to false
 #ComputeSriovInterface1=p1p1
@@ -244,7 +248,7 @@ sriov_enable=false
 
 #Enter the number of VFs you want to create per port
 #Supported values are between 1-64
-sriov_vf_count=5
+sriov_vf_count=64
 
 # Set to True to enable DVR
 # Note: DVR requires different NIC configuration

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -81,10 +81,10 @@ tenant_tunnel_network_vlanid=130
 tenant_vlan_range=201:250
 
 [MTU Settings]
-# The mtu_selection setting defines whether to use the "global" or "per_network" option. If the mtu_selection is defined as "global", the mtu value for all networks will be set to the value provided in mtu_size_global_default. The supported value must be within the range of 1500-9000. If the "per_network"  is defined, the user should provide an mtu value for each network in the range of 1500-9000.
-# For "public_api_network_mtu"  and  "floating_ip_network_mtu" networks, mtu sizes greater than 1500 is only supported if jumbo frames are enabled on upstream routers.
-
-# global | per_network
+# The mtu_selection setting defines whether to use the "global" or "per_network" option. 
+# If the mtu_selection is defined as "global", the mtu value for all networks will be set to the value provided in mtu_size_global_default. The supported value must be within the range of 1500-9000.
+# If "per_network" mtu_selection is defined, the user should provide an mtu value for each network in the range of 1500-9000.
+# For "public_api_network_mtu" and "floating_ip_network_mtu" networks, mtu sizes greater than 1500 is only supported if jumbo frames are enabled on upstream routers.
 mtu_selection=global 
 mtu_size_global_default=1500
 public_api_network_mtu=1500
@@ -160,17 +160,16 @@ subscription_check_retries=20
 sah_bond_opts=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
 # NIC environment file
-# Note: If using Mellanox 25 gig NICs, change the following to:
-#       4_port/nic_environment.yaml
-#       If you need to enable OVS-DPDK, then use
-#       ovs-dpdk_X_port as nic home directory
-#       where X represents the total number of ports:
-#            9: Five + Four DPDK ports
-#            7: Five + Two DPDK ports
-#       If SR-IOV needs to enable, then use
-#       sriov_9_port or sriov_7_port as nic home directory
-#            9: Five + Four SRIOV ports
-#            7: Five + Two SRIOV ports
+#       1. To enable standard XSP profile or standard CSP profile (NUMA and HugePages):
+#          For 5 ports, choose 5_port/nic_environment.yaml. 
+#          For 4 ports, choose 4_port/nic_environment.yaml
+#       2. To enable OVS-DPDK with 7 nic ports, choose ovs-dpdk_7_port/nic_environment.yaml.
+#          For 9 ports, choose ovs-dpdk_9_port/nic_enviornment.yaml
+#       3. To enable SR-IOV with 7 nic ports, choose sriov_7_port/nic_environment.yaml.
+#          For 9 ports, choose sriov_9_port/nic_enviornment.yaml
+#       4. To enable OVS-DPDK (2-ports) and SR-IOV (2-ports),choose ovs-dpdk_sriov_9_port/nic_environment.yaml
+#       5. To enable DVR, for Storage and Floating networks that share a single bond, choose 5_port/nic_environment.yaml.
+#          If a separate bond is required for Floating network on compute nodes, choose dvr_7_port/nic_environment.yaml
 nic_env_file=5_port/nic_environment.yaml
 
 # Interfaces and bonding options per node type.
@@ -201,10 +200,8 @@ StorageBond1Interface1=em2
 StorageBond1Interface2=p2p2
 StorageBondInterfaceOptions=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
-# Note: the following interfaces need to be changed
-# as per the server model
-# R640 should use 'p2p1', 'p3p1', 'p2p2', 'p3p2'
-# R740/R740xd should use 'p4p1', 'p5p1', 'p4p2', 'p5p2'
+# To enable standalone OVS-DPDK, two or four interfaces should be used.
+# To enable OVS-DPDK with SR-IOV, two interfaces should be used.
 # The following lines should be commented out  if ovs_dpdk_enable is set to false
 #ComputeOvsDpdkInterface1=p2p1
 #ComputeOvsDpdkInterface2=p3p1
@@ -212,9 +209,8 @@ StorageBondInterfaceOptions=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 la
 #ComputeOvsDpdkInterface4=p3p2
 #BondInterfaceOvsOptions=bond_mode=balance-tcp lacp=active
 
-# Note: the following interfaces need to be changed as per the server model
-# To enable standalone SR-IOV, two or four interfaces should be used
-# For enabling SR-IOV with OVS-DPDK, two interfaces should be used.
+# To enable standalone SR-IOV, two or four interfaces should be used.
+# To enable SR-IOV with OVS-DPDK, two interfaces should be used.
 # Following lines should be commented out if sriov_enable is set to false
 #ComputeSriovInterface1=p1p1
 #ComputeSriovInterface2=p4p1
@@ -222,7 +218,6 @@ StorageBondInterfaceOptions=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 la
 #ComputeSriovInterface4=p4p2
 
 [Dell NFV Settings]
-#Provide NFV features here.
 
 #Enter value of enable_hpg as true/false for HugePages
 hpg_enable=false
@@ -239,7 +234,7 @@ numa_enable=false
 ovs_dpdk_enable=false
 
 #Enter number of cores you want to reserve for Host OS
-#Supported values are 2 or 4 or 6 or 8
+#Supported values are 2,4,6,8
 numa_hostos_cpu_count=4
 
 # SRIOV Settings
@@ -250,13 +245,7 @@ sriov_enable=false
 #Supported values are between 1-64
 sriov_vf_count=64
 
-# Set to True to enable DVR
-# Note: DVR requires different NIC configuration
-# Change nic_env_file path accordingly
-# Storage and Floating networks share a single bond when nic_env_file parameter
-# is set to default value of either 5_port/nic_environment.yaml.
-# If a separate bond is required for Floating network on compute nodes, set the nic_env_file
-# parameter to dvr_7_port/nic_environment.yaml
+# Set to true to enable DVR
 dvr_enable=false
 
 
@@ -327,8 +316,6 @@ enable_rbd_backend=true
 enable_rbd_nova_backend=true
 
 # Set to false to disable fencing
-# Please refer to the following document for more details on fencing:
-# Dell EMC NFV Ready Bundle for Red Hat Software Deployment Guide
 enable_fencing=true
 
 


### PR DESCRIPTION
- Fixed names of sriov network environment files from "sriov_7_ports"/"sriov_9_ports" to "sriov_7_port"/"sriov_9_port" to follow the same naming pattern.
- Fixed typo in the comment.
- changed default value of "sriov_vf_count" parameter. 