### PR TITLE
Fix setting boot_mode and spurious IB introspection

### DIFF
--- a/src/pilot/import_nodes.py
+++ b/src/pilot/import_nodes.py
@@ -28,6 +28,8 @@ from logging_helper import LoggingHelper
 logging.basicConfig()
 logger = logging.getLogger(os.path.splitext(os.path.basename(sys.argv[0]))[0])
 
+DOWNSTREAM_ATTRS = ["model", "provisioning_mac", "service_tag"]
+
 
 def parse_arguments():
     parser = argparse.ArgumentParser(
@@ -51,7 +53,7 @@ def main():
     content = json.load(open(args.node_definition))
     for node in content['nodes']:
         for k in node.keys():
-            if not k.startswith('pm_'):
+            if k in DOWNSTREAM_ATTRS:
                 node.pop(k)
     with open(import_json, 'w') as out:
         json.dump(content, out)

--- a/src/pilot/prep_overcloud_nodes.py
+++ b/src/pilot/prep_overcloud_nodes.py
@@ -33,12 +33,6 @@ def parse_arguments():
 
     LoggingHelper.add_argument(parser)
 
-    parser.add_argument('-s', '--skip',
-                        action='store_true',
-                        default=False,
-                        help="Skip assigning the kernel and ramdisk images to "
-                             "all nodes")
-
     return parser.parse_args()
 
 
@@ -70,14 +64,6 @@ def main():
         cmd = "openstack baremetal node set --driver-info " + \
               "force_persistent_boot_device=True " + node
         logger.debug("    {}".format(cmd))
-        os.system(cmd)
-
-    if not args.skip:
-
-        cmd = "openstack overcloud node introspect --all-manageable --provide"
-
-        logger.info("Assigning the kernel and ramdisk image to all nodes")
-        logger.debug(cmd)
         os.system(cmd)
 
 


### PR DESCRIPTION
This patch fixes the import_nodes.py script so that it allows the
boot_mode specified in the capabilities in the instack file to
be set on the nodes in ironic.

It also removes running in-band introspection against the
overcloud nodes in the prep script.  This makes deployment
run faster since OOB introspection is now used.