### PR TITLE
Enforce IB introspection for CSP profile

### DIFF
--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -420,11 +420,11 @@ overcloud_deploy_timeout=120
 # Default driver is DRAC.
 use_ipmi_driver=false
 
-# Default introspection method is out-of-band.
+# Default introspection method is in-band.
 # Note that out-of-band introspection is only supported by the DRAC driver.  If
 # use_ipmi_driver is set to "true" above then in-band introspection will be
 # used regardless of the value below.
-use_in_band_introspection=false
+use_in_band_introspection=true
 
 # RDO cloud images
 # Available to download @ https://access.redhat.com/downloads/content/191/ver=8/rhel---7/8/x86_64/product-software


### PR DESCRIPTION
Evidently NUMA and hugepages require IB introspection, so enforce IB introspection for the CSP profile.