### PR TITLE
Add support for Glance Backend Option

### DIFF
--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -438,6 +438,7 @@ class Director(InfraHost):
         osd_dedicated_devices = "    dedicated_devices:\n"
         domain_param = "  CloudDomain:"
         rbd_backend_param = "  NovaEnableRbdBackend:"
+        glance_backend_param = "  GlanceBackend:"
         ceph_pool_default_size_param = "  CephPoolDefaultSize:"
         ceph_pool_default_size = 3
         osds_per_node = 0
@@ -534,6 +535,10 @@ class Director(InfraHost):
             elif line.startswith(rbd_backend_param):
                 value = str(self.settings.enable_rbd_nova_backend).lower()
                 tmp_file.write("{} {}\n".format(rbd_backend_param, value))
+
+            elif line.startswith(glance_backend_param):
+                value = str(self.settings.glance_backend).lower()
+                tmp_file.write("{} {}\n".format(glance_backend_param, value))
 
             elif line.startswith(ceph_pool_default_size_param):
                 tmp_file.write("{} {}\n".format(ceph_pool_default_size_param,

--- a/src/deploy/osp_deployer/profiles/csp.json
+++ b/src/deploy/osp_deployer/profiles/csp.json
@@ -196,6 +196,14 @@
                   "false"
                ]
             },
+            "glance_backend": {
+               "valid_values": [
+                  "file",
+                  "rbd",
+                  "cinder",
+                  "swift"
+               ]
+            },
          "enable_fencing":""
          }
       },

--- a/src/deploy/osp_deployer/profiles/xsp.json
+++ b/src/deploy/osp_deployer/profiles/xsp.json
@@ -184,6 +184,14 @@
                   "false"
                ]
             },
+            "glance_backend": {
+               "valid_values": [
+                  "file",
+                  "rbd",
+                  "cinder",
+                  "swift"
+               ]
+            },
          "enable_fencing":""
          }
       },

--- a/src/deploy/osp_deployer/settings/config.py
+++ b/src/deploy/osp_deployer/settings/config.py
@@ -273,6 +273,9 @@ class Settings():
         else:
             self.enable_rbd_nova_backend = False
 
+        #glance backend, possible values file, cinder, swift or rbd
+        self.glance_backend = deploy_settings['glance_backend'].lower()
+
         if deploy_settings['enable_fencing'].lower() == 'true':
             self.enable_fencing = True
         else:

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -333,6 +333,9 @@ enable_rbd_backend=true
 # If set to false, Nova uses the storage local to the compute.
 enable_rbd_nova_backend=true
 
+# Set the glance backend. Vaules are file, rbd ,swift or cinder
+glance_backend=rbd
+
 # Set to false to disable fencing
 enable_fencing=true
 

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -333,6 +333,9 @@ enable_rbd_backend=true
 # If set to false, Nova uses the storage local to the compute.
 enable_rbd_nova_backend=true
 
+# Set the glance backend. Vaules are file, rbd, swift or cinder
+glance_backend=rbd
+
 # Set to false to disable fencing
 enable_fencing=true
 

--- a/src/pilot/templates/dell-environment.yaml
+++ b/src/pilot/templates/dell-environment.yaml
@@ -84,6 +84,10 @@ parameter_defaults:
   # Set to true to enable Nova usage of Ceph for ephemeral storage.
   # If set to false, Nova uses the storage local to the compute.
   NovaEnableRbdBackend: true
+
+  # Backend to use for glance, options are file, cinder, rbd
+  GlanceBackend: rbd
+
   #  devices:
   #  - /dev/sda2
 


### PR DESCRIPTION
Define the backend to use for Glance in the ini file.
For cinder
glance_backend=cinder
Set to rbd to use ceph as backend.
glance_backend=rbd
Set to file to use file-based storage for images.
glance_backend=file
And deploy overcloud
Note: cinder has to be configured to use the right backend
if cinder is choosen