### PR TITLE
Handle tempest config if public network not avail

### DIFF
--- a/src/deploy/osp_deployer/deployer.py
+++ b/src/deploy/osp_deployer/deployer.py
@@ -58,6 +58,9 @@ def get_settings():
                         help='Only validate ini and properties files ' +
                         '(no deployment)',
                         action='store_true', required=False)
+    parser.add_argument('-tempest_config_only', '--tempest_config_only',
+                        help='Only (re-)generate the tempest.conf file.',
+                        action='store_true', required=False)
     args, ignore = parser.parse_known_args()
     settings = Settings(args.settings)
     return settings
@@ -100,6 +103,9 @@ def deploy():
                         help='No deployment - just validate config values',
                         action='store_true',
                         required=False)
+    parser.add_argument('-tempest_config_only', '--tempest_config_only',
+                        help='Only (re-)generate the tempest.conf file.',
+                        action='store_true', required=False)
     args, others = parser.parse_known_args()
     try:
         if len(others) > 0:
@@ -136,6 +142,13 @@ def deploy():
         sah_node = Sah()
 
         tester.sah_health_check()
+
+        if args.tempest_config_only:
+            logger.info("Only (re-)generating tempest.conf")
+            director_vm = Director()
+            director_vm.configure_tempest()
+            os._exit(0)
+
         logger.info("Uploading configs/iso/scripts..")
         sah_node.clear_known_hosts()
         sah_node.handle_lock_files()

--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -1520,13 +1520,24 @@ class Director(InfraHost):
             pass
 
     def configure_tempest(self):
-        logger.debug("configuring tempest")
+        logger.debug("Configuring tempest")
         setts = self.settings
+        external_sub_cmd = ("source ~/" + setts.overcloud_name + "rc;" +
+                            "openstack subnet list  | grep external_sub " +
+                            "| awk '{print $6;}'")
+        external_sub_guid = self.run_tty(external_sub_cmd)[0].rstrip()
+
+        if not external_sub_guid:
+            logger.error("Could not find public network, please run the " +
+                        "sanity test to create the appropriate networks " +
+                        "and re-run this script with " +
+                        "--tempest_config_only flag.")
+            pass
+
         cmds = [
-            'source ~/' + self.settings.overcloud_name + 'rc;'
-            "sudo ip route add " + self.settings.floating_ip_network +
-            " dev eth0",
-            'source ~/' + self.settings.overcloud_name + 'rc;' +
+            'source ~/' + setts.overcloud_name + 'rc;'
+            "sudo ip route add " + setts.floating_ip_network + " dev eth0",
+            'source ~/' + setts.overcloud_name + 'rc;' +
             'tempest init mytempest;cd mytempest;' +
             'discover-tempest-config --deployer-input ' +
             '~/tempest-deployer-input.conf --debug --create --network-id ' +

--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -1536,7 +1536,8 @@ class Director(InfraHost):
 
         cmds = [
             'source ~/' + setts.overcloud_name + 'rc;'
-            "sudo ip route add " + setts.floating_ip_network + " dev eth0",
+            "sudo ip route add " + setts.floating_ip_network +
+            " dev eth0",
             'source ~/' + setts.overcloud_name + 'rc;' +
             'tempest init mytempest;cd mytempest;' +
             'discover-tempest-config --deployer-input ' +

--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -1531,11 +1531,11 @@ class Director(InfraHost):
         external_sub_guid = self.run_tty(external_sub_cmd)[0].rstrip()
 
         if not external_sub_guid:
-            logger.error("Could not find public network, please run the " +
-                         "sanity test to create the appropriate networks " +
-                         "and re-run this script with " +
-                         "--tempest_config_only flag.")
-            pass
+            err = ("Could not find public network, please run the "
+                   + "sanity test to create the appropriate networks "
+                   + "and re-run this script with the "
+                   + "--tempest_config_only flag.")
+            raise AssertionError(err)
 
         self._backup_tempest_conf()
 
@@ -1557,12 +1557,11 @@ class Director(InfraHost):
             self.run_tty(cmd)
 
     def run_tempest(self):
-        logger.debug("Running tempest")
+        logger.info("Running tempest")
 
         if not self._is_tempest_conf():
             self.configure_tempest()
 
-        os._exit(0)
         setts = self.settings
         cmd = 'source ~/' + self.settings.overcloud_name + 'rc;cd ' + \
             '~/' + TEMPEST_DIR + ';' + \
@@ -1605,7 +1604,7 @@ class Director(InfraHost):
 
     def _backup_tempest_conf(self):
         logger.info("Backing up tempest.conf")
-        if self.is_tempest_conf():
+        if self._is_tempest_conf():
             timestamp = int(round(time.time() * 1000))
             new_conf = (TEMPEST_DIR + "/etc/" + TEMPEST_CONF + "."
                         + str(timestamp))

--- a/src/mgmt/osp-sah.ks
+++ b/src/mgmt/osp-sah.ks
@@ -575,7 +575,7 @@ subscription-manager register --username ${SMUser} --password ${SMPassword} ${Pr
          subscription-manager attach --auto ${ProxyInfo}
          )
 
-subscription-manager repos ${ProxyInfo} '--disable=*' --enable=rhel-7-server-rpms
+subscription-manager repos ${ProxyInfo} '--disable=*' --enable=rhel-7-server-rpms --enable=rhel-7-server-optional-rpms
 
 systemctl disable NetworkManager
 systemctl disable firewalld

--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -57,16 +57,6 @@ fi
 flavors="control compute ceph-storage"
 subnet_name="ctlplane"
 
-# Configure a cleaning network so that the Bare Metal service, ironic, can use
-# node cleaning.
-configure_cleaning_network()
-{
-  network_name="$1"
-  network_uuid=$(openstack network list | grep "${network_name}" | awk '{print $2}')
-  sudo sed -i.bak "s/^.*cleaning_network_uuid.*$/cleaning_network_uuid\ =\ $network_uuid/" /etc/ironic/ironic.conf
-  sudo systemctl restart openstack-ironic-conductor.service
-}
-
 # Create the requested flavor if it does not exist.
 # Set the properties of the flavor regardless.
 create_flavor()
@@ -321,12 +311,6 @@ echo "## Done"
 echo
 echo "## Restarting openstack-ironic-conductor.service..."
 sudo systemctl restart openstack-ironic-conductor.service
-echo "## Done."
-
-network="ctlplane"
-echo
-echo "## Configuring neutron network ${network} as a cleaning network"
-configure_cleaning_network $network
 echo "## Done."
 
 # If deployment is unlocked, generate the overcloud container list from the latest.

--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -57,6 +57,16 @@ fi
 flavors="control compute ceph-storage"
 subnet_name="ctlplane"
 
+# Configure a cleaning network so that the Bare Metal service, ironic, can use
+# node cleaning.
+configure_cleaning_network()
+{
+  network_name="$1"
+  network_uuid=$(openstack network list | grep "${network_name}" | awk '{print $2}')
+  sudo sed -i.bak "s/^.*cleaning_network_uuid.*$/cleaning_network_uuid\ =\ $network_uuid/" /etc/ironic/ironic.conf
+  sudo systemctl restart openstack-ironic-conductor.service
+}
+
 # Create the requested flavor if it does not exist.
 # Set the properties of the flavor regardless.
 create_flavor()
@@ -311,6 +321,12 @@ echo "## Done"
 echo
 echo "## Restarting openstack-ironic-conductor.service..."
 sudo systemctl restart openstack-ironic-conductor.service
+echo "## Done."
+
+network="ctlplane"
+echo
+echo "## Configuring neutron network ${network} as a cleaning network"
+configure_cleaning_network $network
 echo "## Done."
 
 # If deployment is unlocked, generate the overcloud container list from the latest.

--- a/src/pilot/prep_overcloud_nodes.py
+++ b/src/pilot/prep_overcloud_nodes.py
@@ -62,6 +62,10 @@ def main():
             node + " pxe"
         logger.debug("    {}".format(cmd))
         os.system(cmd)
+        cmd = "openstack baremetal node set --driver-info " + \
+              "force_persistent_boot_device=True " + node
+        logger.debug("    {}".format(cmd))
+        os.system(cmd)
 
 
 if __name__ == "__main__":

--- a/src/pilot/templates/manila-unity-config.yaml
+++ b/src/pilot/templates/manila-unity-config.yaml
@@ -1,0 +1,19 @@
+# This environment file enables Manila with the Unity backend.
+resource_registry:
+  OS::TripleO::Services::ManilaApi: ./overcloud/docker/services/manila-api.yaml
+  OS::TripleO::Services::ManilaScheduler: ./overcloud/docker/services/manila-scheduler.yaml
+  # Only manila-share is pacemaker managed:
+  OS::TripleO::Services::ManilaShare: ./overcloud/docker/services/pacemaker/manila-share.yaml
+  OS::TripleO::Services::ManilaBackendUnity: ./overcloud/puppet/services/manila-backend-unity.yaml
+
+parameter_defaults:
+  ManilaUnityBackendName: tripleo_manila_unity
+  ManilaUnityDriverHandlesShareServers: <manila_unity_driver_handles_share_servers> 
+  ManilaUnityNasLogin: <manila_unity_nas_login>
+  ManilaUnityNasPassword: <manila_unity_nas_password>
+  ManilaUnityNasServer: <manila_unity_nas_server>
+  ManilaUnityServerMetaPool: <manila_unity_server_meta_pool>
+  ManilaUnityShareDataPools: <manila_unity_share_data_pools>
+  ManilaUnityEthernetPorts: <manila_unity_ethernet_ports>
+  ManilaUnityEmcSslCertVerify: <manila_unity_ssl_cert_verify>
+  ManilaUnityEmcSslCertPath: <manila_unity_ssl_cert_path>


### PR DESCRIPTION
If sanity test is not run prior to attempting to
configure tempest an excption would occur when the
tempest configuration script was called.  This patch
insures that the network the config script requires
is present, if it is not then the user is instructed
to run the sanity test to create the network and
to rerun the deployment with the --tempest_config_only
flag.

Also added --tempest_config_only flag to help user
recover from error where tempest.conf could not be
generated due to the sanity test failing or not
running at all, as executing it is currently an
option.

Fixes: CES-10320