### PR TITLE
Fix for CES-10391: list_controllers fails due to ASCII 3

### DIFF
--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -269,6 +269,17 @@ sudo rm -f /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/raid.pyc
 sudo rm -f /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/raid.pyo
 echo "## Done."
 
+# This hacks in a patch to filter out all non-printable characters during WSMAN
+# enumeration.
+# Note that this code must be here because we use this code prior to deploying
+# the director.
+echo
+echo "## Patching Ironic iDRAC driver wsman.py..."
+apply_patch "sudo patch -b -s /usr/lib/python2.7/site-packages/dracclient/wsman.py ${HOME}/pilot/wsman.patch"
+sudo rm -f /usr/lib/python2.7/site-packages/dracclient/wsman.pyc
+sudo rm -f /usr/lib/python2.7/site-packages/dracclient/wsman.pyo
+echo "## Done."
+
 # This patches workarounds for two issues into ironic.conf.
 # 1. node_locked_retry_attempts is increased to work around an issue where
 #    lock contention on the nodes in ironic can occur during RAID cleaning.

--- a/src/pilot/wsman.patch
+++ b/src/pilot/wsman.patch
@@ -1,0 +1,16 @@
+--- /usr/lib/python2.7/site-packages/dracclient/wsman.py	2019-02-14 22:02:46.675635747 +0000
++++ wsman.py	2019-02-14 22:38:30.019394221 +0000
+@@ -163,8 +163,11 @@
+             resp_xml = ElementTree.fromstring(resp.content)
+         except ElementTree.XMLSyntaxError:
+             LOG.warning('Received invalid content from iDRAC.  Filtering out '
+-                        'non-ASCII characters: ' + repr(resp.content))
+-            resp_xml = ElementTree.fromstring(re.sub(six.b('[^\x00-\x7f]'),
++                        'unprintable characters: ' + repr(resp.content))
++
++            # Filter out everything except for printable ASCII characters and
++            # tab
++            resp_xml = ElementTree.fromstring(re.sub(six.b('[^\x20-\x7e\t]'),
+                                                      six.b(''),
+                                                      resp.content))
+ 


### PR DESCRIPTION
This patch fixes python-dracclient so that it filters out all
non-printable characters during an enumeration instead of just
non-ASCII characters.