### PR TITLE
Fix for CES-10376: Sanity test is failing to ping vlan-aware VM

### DIFF
--- a/src/pilot/deployment-validation/sanity_test.sh
+++ b/src/pilot/deployment-validation/sanity_test.sh
@@ -502,7 +502,7 @@ ping_from_netns(){
       break
     fi
   done
-
+  sleep 20
   info "### Pinging $ip from netns $name_space on controller $controller"
   execute_command "ssh ${SSH_OPTS} heat-admin@$controller sudo ip netns exec ${name_space} ping -c 1 -w 5 ${ip}"
   if [[ "$?" == 0 ]]
@@ -527,7 +527,7 @@ ping_from_snat_netns(){
       break
     fi
   done
-
+  sleep 20
   info "### Pinging $ip from netns $name_space on controller $controller"
   execute_command "ssh ${SSH_OPTS} heat-admin@$controller sudo ip netns exec ${name_space} ping -c 1 -w 5 ${ip}"
   if [[ "$?" == 0 ]]

--- a/src/pilot/nfv_parameters.py
+++ b/src/pilot/nfv_parameters.py
@@ -267,7 +267,7 @@ class NfvParameters(object):
 
     def calculate_hugepage_count(self, hugepage_size):
         try:
-            memory_count = self.get_minimum_memory_size("compute")
+            memory_count = int(self.get_minimum_memory_size("compute"))
             # RAM size should be more than 128G
             if memory_count < 128000:
                 raise Exception("RAM size is less than 128GB"


### PR DESCRIPTION
Sanity was trying to ping the VM before it was active. Adding the delay of 20 gives the instance time to be active before sanity test can ping it.