### PR TITLE
Fix iDRAC reset

### DIFF
--- a/src/pilot/client.patch
+++ b/src/pilot/client.patch
@@ -1,28 +1,30 @@
---- client.py	2019-01-31 00:23:52.000000000 -0500
-+++ client_new.py	2019-01-31 01:33:53.000000000 -0500
-@@ -972,14 +972,23 @@
-         """
-         return self._raid_mgmt.is_raid_controller(raid_controller_fqdd)
+--- /usr/lib/python2.7/site-packages/dracclient/client.py	2019-02-15 20:14:23.863509901 +0000
++++ client.py	2019-02-15 20:14:16.685378567 +0000
+@@ -272,7 +272,7 @@
+         state_reached = self._wait_for_host_state(
+             self.client.host,
+             alive=False,
+-            ping_count=3,
++            ping_count=2,
+             retries=24)
  
--    def is_boss_controller(self, raid_controller_fqdd):
-+    def is_boss_controller(self, raid_controller_fqdd, raid_controllers=None):
-         """Find out if a RAID controller a BOSS card or not
+         if not state_reached:
+@@ -785,7 +785,7 @@
+         return self._raid_mgmt.delete_virtual_disk(virtual_disk)
  
-         :param raid_controller_fqdd: The object's fqdd we are testing to see
-                                      if it is a BOSS card or not.
-+        :param raid_controllers: A list of RAIDController to scan for presence
-+                                 of BOSS card, if None the drac will be queried
-+                                 for the list of controllers which will then be
-+                                 scanned.
-         :returns: boolean, True if the device is a BOSS card, False if not.
-+        :raises: WSManRequestFailure on request failures
-+        :raises: WSManInvalidResponse when receiving invalid response
-+        :raises: DRACOperationFailed on error reported back by the DRAC
-+                 interface
-         """
--        return self._raid_mgmt.is_boss_controller(raid_controller_fqdd)
-+        return self._raid_mgmt.is_boss_controller(raid_controller_fqdd,
-+                                                  raid_controllers)
+     def commit_pending_raid_changes(self, raid_controller, reboot=False,
+-                                    start_time='TIME_NOW'):
++                                    start_time='TIME_NOW', realtime=False):
+         """Applies all pending changes on a RAID controller
  
-     def change_physical_disk_state(self, mode,
-                                    controllers_to_physical_disk_ids=None):
+          ...by creating a config job.
+@@ -811,7 +811,8 @@
+             cim_name='DCIM:RAIDService',
+             target=raid_controller,
+             reboot=reboot,
+-            start_time=start_time)
++            start_time=start_time,
++            realtime=realtime)
+ 
+     def abandon_pending_raid_changes(self, raid_controller):
+         """Deletes all pending changes on a RAID controller


### PR DESCRIPTION
The current code waits for 3 consecutive failed pings, each 10 seconds
apart to determine that an iDRAC has gone down during an iDRAC reset.
This is too long for some servers, as the iDRAC may come back up before
the 3rd ping failure. This results in a failure to detect the iDRAC
going down, which causes a timeout on the reset. This patch changes the
code to wait for only 2 consecutive ping failures, which is what our
highly tested downstream code does.