### PR TITLE
Fixes OSD config generation

### DIFF
--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -908,7 +908,7 @@ def generate_osd_config(ip_mac_service_tag, drac_client):
         return
 
     LOG.info("Generating OSD config for {ip}".format(ip=ip_mac_service_tag))
-    system_id = drac_client.get_system().id
+    system_id = drac_client.get_system().uuid
 
     spinners, ssds = get_drives(drac_client)
 


### PR DESCRIPTION
The OSD configs need to be indexed by the UUID of the server, not the ID.