### PR TITLE
Autocalculate pg_nums

### DIFF
--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -417,7 +417,6 @@ class Director(InfraHost):
     def clamp_min_pgs(self, num_pgs):
         pg_options = [8192, 4096, 2048, 1024, 512, 256, 128, 64, 32, 16, 8, 4,
                       2, 1]
-        pg_max = pg_options[0]
 
         option_index = 0
         finding_pg_value = True

--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -35,9 +35,8 @@ exitFlag = 0
 
 # Ceph pools present in a default install
 HEAVY_POOLS = ['volumes', 'images', 'vms']
-OTHER_POOLS = ['rbd', '.rgw.root', 'default.rgw.control',
-               'default.rgw.data.root', 'default.rgw.gc', 'default.rgw.log',
-               'metrics', 'backups', '.rgw.buckets', 'default.rgw.users.uid']
+OTHER_POOLS = ['.rgw.root', 'default.rgw.control', 'default.rgw.meta',
+               'default.rgw.log', 'metrics', 'backups', '.rgw.buckets' ]
 
 
 class Director(InfraHost):

--- a/src/deploy/osp_deployer/infra_host.py
+++ b/src/deploy/osp_deployer/infra_host.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2015-2018 Dell Inc. or its subsidiaries.
+# Copyright (c) 2015-2019 Dell Inc. or its subsidiaries.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/deploy/osp_deployer/infra_host.py
+++ b/src/deploy/osp_deployer/infra_host.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2015-2019 Dell Inc. or its subsidiaries.
+# Copyright (c) 2015-2018 Dell Inc. or its subsidiaries.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -69,5 +69,12 @@ class InfraHost():
         Scp.put_file(self.ip,
                      "root",
                      self.root_pwd,
+                     local_file,
+                     remote_file)
+
+    def download_file(self, local_file, remote_file):
+        Scp.get_file(self.ip,
+                     self.user,
+                     self.pwd,
                      local_file,
                      remote_file)

--- a/src/deploy/osp_deployer/settings/config.py
+++ b/src/deploy/osp_deployer/settings/config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2015-2019 Dell Inc. or its subsidiaries.
+# Copyright (c) 2015-2018 Dell Inc. or its subsidiaries.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -27,6 +27,8 @@ logger = logging.getLogger("osp_deployer")
 
 
 class Settings():
+    CEPH_OSD_CONFIG_FILE = 'pilot/templates/ceph-osd-config.yaml'
+
     settings = ''
 
     def __init__(self, settings_file):
@@ -352,8 +354,6 @@ class Settings():
                 'unity_san_login']
             self.unity_san_password = backend_settings[
                 'unity_san_password']
-            self.unity_storage_protocol = backend_settings[
-                'unity_storage_protocol']
             self.unity_io_ports = backend_settings[
                 'unity_io_ports']
             self.unity_storage_pool_names = backend_settings[
@@ -494,6 +494,8 @@ class Settings():
             '/pilot/templates/dell-cinder-backends.yaml'
         self.dell_unity_cinder_yaml = self.foreman_configuration_scripts + \
             '/pilot/templates/dellemc-unity-cinder-backend.yaml'
+        self.ceph_osd_config_yaml = self.foreman_configuration_scripts + \
+            '/pilot/templates/ceph-osd-config.yaml'
         self.dell_env_yaml = self.foreman_configuration_scripts + \
             '/pilot/templates/dell-environment.yaml'
         self.neutron_ovs_dpdk_yaml = self.foreman_configuration_scripts + \

--- a/src/deploy/osp_deployer/settings/config.py
+++ b/src/deploy/osp_deployer/settings/config.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright (c) 2015-2018 Dell Inc. or its subsidiaries.
+# Copyright (c) 2015-2019 Dell Inc. or its subsidiaries.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -354,6 +354,8 @@ class Settings():
                 'unity_san_login']
             self.unity_san_password = backend_settings[
                 'unity_san_password']
+            self.unity_storage_protocol = backend_settings[
+                'unity_storage_protocol']
             self.unity_io_ports = backend_settings[
                 'unity_io_ports']
             self.unity_storage_pool_names = backend_settings[

--- a/src/deploy/osp_deployer/settings/config.py
+++ b/src/deploy/osp_deployer/settings/config.py
@@ -497,7 +497,7 @@ class Settings():
         self.dell_unity_cinder_yaml = self.foreman_configuration_scripts + \
             '/pilot/templates/dellemc-unity-cinder-backend.yaml'
         self.ceph_osd_config_yaml = self.foreman_configuration_scripts + \
-            '/pilot/templates/ceph-osd-config.yaml'
+            '/' + CEPH_OSD_CONFIG_FILE
         self.dell_env_yaml = self.foreman_configuration_scripts + \
             '/pilot/templates/dell-environment.yaml'
         self.neutron_ovs_dpdk_yaml = self.foreman_configuration_scripts + \

--- a/src/pilot/templates/dell-environment.yaml
+++ b/src/pilot/templates/dell-environment.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2018 Dell Inc. or its subsidiaries.
+# Copyright (c) 2016-2019 Dell Inc. or its subsidiaries.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/pilot/templates/dell-environment.yaml
+++ b/src/pilot/templates/dell-environment.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2019 Dell Inc. or its subsidiaries.
+# Copyright (c) 2016-2018 Dell Inc. or its subsidiaries.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -93,8 +93,7 @@ parameter_defaults:
 
 
   # Configure Ceph Placement Group (PG) values for the indicated pools
-  CephPools: [{"name": "volumes", "pg_num": 1024, "pgp_num": 1024}, {"name": "vms", "pg_num": 256, "pgp_num": 256},
-{"name": "images", "pg_num": 128, "pgp_num": 128}, {"name": ".rgw.buckets", "pg_num": 512, "pgp_num": 512}]
+  CephPools: [{"name": "volumes", "pg_num": 128, "pgp_num": 128}, {"name": "vms", "pg_num": 128, "pgp_num": 128}, {"name": "images", "pg_num": 128, "pgp_num": 128}, {"name": ".rgw.buckets", "pg_num": 64, "pgp_num": 64}]
 
   CephAnsiblePlaybookVerbosity: 1
   


### PR DESCRIPTION
This patch changes the ceph configuration so that instead of reducing the replication count to fit hardcoded pg_nums and the number of OSDs in the cluster, it counts up the number of OSDs in the cluster, leaves the replication factor set to 3, and calculates what the pg_nums should be for each pool.  It then updates the dell-environment.yaml with these numbers.