### PR TITLE
Set overcloud nodes to pxe boot permanently

### DIFF
--- a/src/pilot/prep_overcloud_nodes.py
+++ b/src/pilot/prep_overcloud_nodes.py
@@ -58,11 +58,8 @@ def main():
         # Set the first boot device to PXE
         logger.info("Setting the provisioning NIC to PXE boot on node " + node)
 
-        cmd = "openstack baremetal node boot device set " + node + " pxe"
-        logger.debug("    {}".format(cmd))
-        os.system(cmd)
-        cmd = "openstack baremetal node set --driver-info " + \
-              "force_persistent_boot_device=True " + node
+        cmd = "openstack baremetal node boot device set --persistent " + \
+            node + " pxe"
         logger.debug("    {}".format(cmd))
         os.system(cmd)
 


### PR DESCRIPTION
This patch make the prep script correctly set the overcloud nodes to pxe boot permanently.

The prior code made the overcloud nodes PXE boot one time only.