### PR TITLE
Handle tempest config if public network not avail

### DIFF
--- a/src/deploy/osp_deployer/deployer.py
+++ b/src/deploy/osp_deployer/deployer.py
@@ -147,7 +147,7 @@ def deploy():
             director_vm.run_tempest()
             os._exit(0)
 
-        logger.info("Uploading configs/iso/scripts..")
+        logger.info("Uploading configs/iso/scripts.")
         sah_node.clear_known_hosts()
         sah_node.handle_lock_files()
         sah_node.upload_iso()
@@ -226,9 +226,7 @@ def deploy():
         director_vm.node_introspection()
         director_vm.update_sshd_conf()
         director_vm.assign_node_roles()
-        # Should we be calling function below?
-        # director_vm.revert_sshd_conf()?
-        director_vm.revert_sshd_conf
+        director_vm.revert_sshd_conf()
 
         director_vm.setup_templates()
         logger.info("=== Installing the overcloud ")

--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -780,10 +780,10 @@ class Director(InfraHost):
     def setup_unity_cinder(self, dell_unity_cinder_yaml):
 
         if self.settings.enable_unity_backend is False:
-            logger.debug("not setting up unity cinder backend")
+            logger.debug("Not setting up unity cinder backend.")
             return
 
-        logger.debug("configuring dell emc unity backend")
+        logger.debug("Configuring dell emc unity backend.")
 
         overcloud_images_file = self.home_dir + "/overcloud_images.yaml"
 
@@ -828,10 +828,10 @@ class Director(InfraHost):
     def setup_unity_manila(self, unity_manila_yaml):
 
         if self.settings.enable_unity_manila_backend is False:
-            logger.debug("not setting up unity manila backend")
+            logger.debug("Not setting up unity manila backend.")
             return
 
-        logger.debug("configuring dell emc unity manila backend")
+        logger.debug("Configuring dell emc unity manila backend.")
 
         overcloud_images_file = self.home_dir + "/overcloud_images.yaml"
 


### PR DESCRIPTION
If sanity test is not run prior to attempting to
configure tempest an excption would occur when the
tempest configuration script was called. This patch
insures that the network the config script requires
is present, if it is not then the user is instructed
to run the sanity test to create the network and
to rerun the deployment with the --tempest_config_only
flag.

Added new mutually exclusive arguments:
--tempest_config_only - helps the user
recover from error where tempest.conf could not be
generated due to the sanity test failing or not
running at all, as executing it is currently an
option. If tempest.conf already exists it is backed
up and a new one created.

--run_tempest_only - Just run Tempest. If no tempest.conf
is found we try to generate one then run.

Lastly, added new mutually exclusive argument group so the
user won't be able to run with both of these new args at the
same time as it will lead to confusion.

Fixes: CES-10320