### PR TITLE
Touch up tempest comments, arg to validate_only

### DIFF
--- a/src/deploy/osp_deployer/deployer.py
+++ b/src/deploy/osp_deployer/deployer.py
@@ -56,11 +56,10 @@ def get_settings():
                         action='store_true',
                         required=False)
     group = parser.add_mutually_exclusive_group()
-    group.add_argument('-validate_settings_only', '--validate_settings_only',
-                        help='Only validate ini and properties files ' +
-                        '(no deployment)',
-                        action='store_true', required=False)
-
+    group.add_argument('-validate_only', '--validate_only',
+                       help='No deployment - just validate config values',
+                       action='store_true',
+                       required=False)
     group.add_argument('-tempest_config_only', '--tempest_config_only',
                        help='Only (re-)generate the tempest.conf file.',
                        action='store_true', required=False)

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -416,8 +416,9 @@ sanity_vlantest_network=192.168.216.0/24
 # If you want to run Tempest post-deployment, you may do so.
 # Note: The sanity test script must be run first to create networks for Tempest.
 run_tempest=false
-# tempest_smoke_only is dependent on run_tempest=true for tempest_smoke_only to
-# have any effect.
+
+# The flag tempest_smoke_only is dependent on run_tempest=true for
+# tempest_smoke_only to have any effect.
 # If run_tempest=true and tempest_smoke_only=true, only a subset of tempest tests
 # tagged as smoke tests will be executed.  This set of tests is useful for validating
 # basic OpenStack functionality.

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -417,8 +417,9 @@ sanity_vlantest_network=192.168.216.0/24
 # If you want to run Tempest post-deployment, you may do so.
 # Note: The sanity test script must be run first to create networks for Tempest.
 run_tempest=false
-# tempest_smoke_only is dependent on run_tempest=true for tempest_smoke_only to
-# have any effect.
+
+# The flag tempest_smoke_only is dependent on run_tempest=true for
+# tempest_smoke_only to have any effect.
 # If run_tempest=true and tempest_smoke_only=true, only a subset of tempest tests
 # tagged as smoke tests will be executed.  This set of tests is useful for validating
 # basic OpenStack functionality.


### PR DESCRIPTION
Arg should have been validate_only not validate_settings_only,
there were two different versions in original and merged wrong
one.