### PR TITLE
Refactor tempest config

### DIFF
--- a/src/deploy/osp_deployer/deployer.py
+++ b/src/deploy/osp_deployer/deployer.py
@@ -264,8 +264,13 @@ def deploy():
             director_vm.configure_dashboard()
         director_vm.enable_fencing()
         director_vm.run_sanity_test()
-        director_vm.configure_tempest()
+
+        external_sub_guid = director_vm.get_sanity_subnet()
+        if external_sub_guid:
+            director_vm.configure_tempest()
+
         run_tempest()
+
         logger.info("Deployment summary info; useful ip's etc.. " +
                     "/auto_results/deployment_summary.log")
 


### PR DESCRIPTION
When doing a full deployment instead of outputting an exception
when sanity test has NOT been run, add a check to see if the
subnet sanity test should have created exists prior to trying
to configure tempest.