### PR TITLE
workaround for tripleo-heat-templates 

### DIFF
--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -295,6 +295,12 @@ echo "## Patching 10-ironic_wsgi.conf"
 apply_patch "sudo patch -b -s /etc/httpd/conf.d/10-ironic_wsgi.conf ${HOME}/pilot/wsgi.patch"
 echo "## Done"
 
+# This patch fixes an issue in tripleo-heat-templates
+echo
+echo "### Patching tripleo-heat-templates"
+sudo sed -i 's/$(get_python)/python/' /usr/share/openstack-tripleo-heat-templates/puppet/extraconfig/pre_deploy/per_node.yaml
+echo "## Done."
+
 # This patch fixes tempest cleanup
 echo
 echo "### Patching tempest cleanup..."

--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -223,6 +223,12 @@ subnet_uuid=$(openstack network list | grep "${subnet_name}" | awk '{print $6}')
 openstack subnet set "${subnet_uuid}" --dns-nameserver "${dns_ip}"
 echo "## Done."
 
+# This patch fixes an issue in tripleo-heat-templates
+echo
+echo "### Patching tripleo-heat-templates"
+sudo sed -i 's/$(get_python)/python/' /usr/share/openstack-tripleo-heat-templates/puppet/extraconfig/pre_deploy/per_node.yaml
+echo "## Done."
+
 echo
 echo "## Copying heat templates..."
 cp -r /usr/share/openstack-tripleo-heat-templates $HOME/pilot/templates/overcloud
@@ -294,12 +300,6 @@ echo
 echo "## Patching 10-ironic_wsgi.conf"
 apply_patch "sudo patch -b -s /etc/httpd/conf.d/10-ironic_wsgi.conf ${HOME}/pilot/wsgi.patch"
 echo "## Done"
-
-# This patch fixes an issue in tripleo-heat-templates
-echo
-echo "### Patching tripleo-heat-templates"
-sudo sed -i 's/$(get_python)/python/' /usr/share/openstack-tripleo-heat-templates/puppet/extraconfig/pre_deploy/per_node.yaml
-echo "## Done."
 
 # This patch fixes tempest cleanup
 echo

--- a/src/pilot/templates/ceph-osd-config.yaml
+++ b/src/pilot/templates/ceph-osd-config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 resource_registry:
-  OS::TripleO::CephStorageExtraConfigPre: ./overcloud/puppet/extraconfig/pre_deploy/per_node.yaml
+  OS::TripleO::CephStorageExtraConfigPre: /usr/share/openstack-tripleo-heat-templates/puppet/extraconfig/pre_deploy/per_node.yaml
 
 parameter_defaults:
   NodeDataLookup: >

--- a/src/pilot/templates/ceph-osd-config.yaml
+++ b/src/pilot/templates/ceph-osd-config.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 resource_registry:
-  OS::TripleO::CephStorageExtraConfigPre: /usr/share/openstack-tripleo-heat-templates/puppet/extraconfig/pre_deploy/per_node.yaml
+  OS::TripleO::CephStorageExtraConfigPre: ./overcloud/puppet/extraconfig/pre_deploy/per_node.yaml
 
 parameter_defaults:
   NodeDataLookup: >


### PR DESCRIPTION
This fixes an issue introduced upstream we picked with the latest ZStream, causing the overcloud deployment to fail 
Root cause is the following commit : 
https://github.com/openstack/tripleo-heat-templates/commit/759b711b9457a5827cf75e8dcb36e3ca905dec1c#diff-801e6ddf38ed5e45c3f6038fefdaf4c6  
