### PR TITLE
Unity: Support specific version of container image

### DIFF
--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -802,27 +802,28 @@ class Director(InfraHost):
 
         overcloud_images_file = self.home_dir + "/overcloud_images.yaml"
 
+        cinder_container = "/dellemc/openstack-cinder-volume-dellemc:" + \
+            self.settings.cinder_unity_container_version
+        remote_registry = "registry.connect.redhat.com"
+        remote_url = remote_registry + cinder_container
+        local_registry = self.provisioning_ip + ":8787"
+        local_url = local_registry + cinder_container
+
         cmds = [
             'docker login -u ' + self.settings.subscription_manager_user +
             ' -p ' + self.settings.subscription_manager_password +
-            ' registry.connect.redhat.com',
-            'docker pull registry.connect.redhat.com' +
-            '/dellemc/openstack-cinder-volume-dellemc',
-            'docker tag registry.connect.redhat.com' +
-            '/dellemc/openstack-cinder-volume-dellemc ' +
-            self.provisioning_ip +
-            ':8787/dellemc/openstack-cinder-volume-dellemc',
-            'docker push ' + self.provisioning_ip +
-            ':8787/dellemc/openstack-cinder-volume-dellemc',
+            ' ' + remote_registry,
+            'docker pull ' + remote_url,
+            'docker tag ' + remote_url + ' ' + local_url,
+            'docker push ' + local_url,
             'sed -i "s|DockerCinderVolumeImage.*|' +
-            'DockerCinderVolumeImage: ' + self.provisioning_ip +
-            ':8787\/dellemc\/openstack-cinder-volume-dellemc' +
+            'DockerCinderVolumeImage: ' + local_url +
             '|" ' + overcloud_images_file,
             'echo "  DockerInsecureRegistryAddress:" >> ' +
             overcloud_images_file,
-            'echo "  - ' + self.provisioning_ip + ':8787 " >> ' +
+            'echo "  - ' + local_registry + ' " >> ' +
             overcloud_images_file,
-            'docker logout registry.connect.redhat.com',
+            'docker logout ' + remote_registry,
             'sed -i "s|<unity_san_ip>|' +
             self.settings.unity_san_ip + '|" ' + dell_unity_cinder_yaml,
             'sed -i "s|<unity_san_login>|' +
@@ -849,28 +850,29 @@ class Director(InfraHost):
 
         logger.debug("Configuring dell emc unity manila backend.")
 
-        overcloud_images_file = self.home_dir + "/overcloud_images.yaml" 
+        overcloud_images_file = self.home_dir + "/overcloud_images.yaml"
+        manila_container = "/dellemc/openstack-manila-share-dellemc:" + \
+             self.settings.manila_unity_container_version
+        remote_registry = "registry.connect.redhat.com"
+        remote_url = remote_registry + manila_container
+        local_registry = self.provisioning_ip + ":8787"
+        local_url = local_registry + manila_container
 
         cmds = [
             'docker login -u ' + self.settings.subscription_manager_user +
             ' -p ' + self.settings.subscription_manager_password +
-            ' registry.connect.redhat.com',
-            'docker pull registry.connect.redhat.com' +
-            '/dellemc/openstack-manila-share-dellemc',
-            'docker tag registry.connect.redhat.com' +
-            '/dellemc/openstack-manila-share-dellemc ' +
-            self.provisioning_ip +
-            ':8787/dellemc/openstack-manila-share-dellemc',
-            'docker push ' + self.provisioning_ip +
-            ':8787/dellemc/openstack-manila-share-dellemc',
-            'sed -i "50i \  DockerManilaShareImage: ' + self.provisioning_ip +
-            ':8787\/dellemc\/openstack-manila-share-dellemc " ' +
-            overcloud_images_file,
+            ' ' + remote_registry,
+            'docker pull ' + remote_url,
+            'docker tag ' + remote_url + ' ' + local_url,
+            'docker push ' + local_url,
+            'sed -i "s|DockerManilaShareImage.*|' +
+            'DockerManilaShareImage: ' + local_url +
+            '|" ' + overcloud_images_file,
             'echo "  DockerInsecureRegistryAddress:" >> ' +
             overcloud_images_file,
-            'echo "  - ' + self.provisioning_ip + ':8787 " >> ' +
+            'echo "  - ' + local_registry + ' " >> ' +
             overcloud_images_file,
-            'docker logout registry.connect.redhat.com',
+            'docker logout ' + remote_registry,
             'sed -i "s|<manila_unity_driver_handles_share_servers>|' +
             self.settings.manila_unity_driver_handles_share_servers +
             '|" ' + unity_manila_yaml,

--- a/src/deploy/osp_deployer/settings/config.py
+++ b/src/deploy/osp_deployer/settings/config.py
@@ -350,6 +350,8 @@ class Settings():
         # unity
         if backend_settings['enable_unity_backend'].lower() == 'true':
             self.enable_unity_backend = True
+            self.cinder_unity_container_version = backend_settings[
+                'cinder_unity_container_version']
             self.unity_san_ip = backend_settings['unity_san_ip']
             self.unity_san_login = backend_settings[
                 'unity_san_login']
@@ -367,6 +369,8 @@ class Settings():
         # Unity Manila
         if backend_settings['enable_unity_manila_backend'].lower() == 'true':
             self.enable_unity_manila_backend = True
+            self.manila_unity_container_version = backend_settings[
+                'manila_unity_container_version']
             self.manila_unity_driver_handles_share_servers = \
                 backend_settings['manila_unity_driver_handles_share_servers']
             self.manila_unity_nas_login = \

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -362,8 +362,15 @@ dellsc_ssn=CHANGEME
 dellsc_server_folder=cmpl_iscsi_servers
 dellsc_volume_folder=cmpl_iscsi_volumes
 
-# Unity cinder parameters. 
+#
+# Unity cinder parameters.
+# 
 enable_unity_backend=false
+# The Dell EMC Unity Container is published in the RH Container Catalog
+# registry.connect.redhat.com.
+# By default, the latest image of the RHOSP13 release is pulled.
+# Change to a different version if a specific image is required.
+cinder_unity_container_version=latest
 unity_backend_name=CHANGEME
 unity_san_ip=CHANGEME
 unity_san_login=CHANGEME
@@ -372,8 +379,15 @@ unity_storage_protocol=iSCSI
 unity_io_ports=CHANGEME
 unity_storage_pool_names=CHANGEME
 
+#
 # Unity manila parameters.
+#
 enable_unity_manila_backend=false
+# The Dell EMC Unity Container is published in the RH Container Catalog
+# registry.connect.redhat.com
+# By default the latest image of the RHOSP release is pulled.
+# Change to a different version if a specific image is required.
+manila_unity_container_version=latest
 manila_unity_driver_handles_share_servers=true
 manila_unity_nas_login=CHANGEME
 manila_unity_nas_password=CHANGEME

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -363,8 +363,15 @@ dellsc_ssn=CHANGEME
 dellsc_server_folder=cmpl_iscsi_servers
 dellsc_volume_folder=cmpl_iscsi_volumes
 
-# Unity cinder parameters. 
+#
+# Unity cinder parameters.
+# 
 enable_unity_backend=false
+# The Dell EMC Unity Container is published in the RH Container Catalog
+# registry.connect.redhat.com
+# By default the latest image of the RHOSP release is pulled.
+# Change to a different version if a specific image is required.
+cinder_unity_container_version=latest
 unity_backend_name=CHANGEME
 unity_san_ip=CHANGEME
 unity_san_login=CHANGEME
@@ -373,8 +380,15 @@ unity_storage_protocol=iSCSI
 unity_io_ports=CHANGEME
 unity_storage_pool_names=CHANGEME
 
+#
 # Unity manila parameters.
+#
 enable_unity_manila_backend=false
+# The Dell EMC Unity Container is published in the RH Container Catalog
+# registry.connect.redhat.com
+# By default the latest image of the RHOSP release is pulled.
+# Change to a different version if a specific image is required.
+manila_unity_container_version=latest
 manila_unity_driver_handles_share_servers=true
 manila_unity_nas_login=CHANGEME
 manila_unity_nas_password=CHANGEME


### PR DESCRIPTION
Adding support to pull a specific version of the custom container for unity. The default is 'latest'. This helps to lock the version if the latest image is bad or not deployable. 