### PR TITLE
Bump up deployment timeout

### DIFF
--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -467,8 +467,8 @@ internal_repos_locations=CHANGEME_INTERNAL_REPO_URL
 cloud_repo_dir=/root/JetPack
 rhel_iso=/root/rhel76.iso
 
-# Overcloud deployment timeout value - default is 120mns, but can be tweaked here if required.
-overcloud_deploy_timeout=120
+# Overcloud deployment timeout value - default is 180mns, but can be tweaked here if required.
+overcloud_deploy_timeout=180
 
 # Default driver is DRAC.
 use_ipmi_driver=false

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -468,8 +468,8 @@ internal_repos_locations=CHANGEME_INTERNAL_REPO_URL
 cloud_repo_dir=/root/JetPack
 rhel_iso=/root/rhel76.iso
 
-# Overcloud deployment timeout value - default is 120mns, but can be tweaked here if required.
-overcloud_deploy_timeout=120
+# Overcloud deployment timeout value - default is 180mns, but can be tweaked here if required.
+overcloud_deploy_timeout=180
 
 # Default driver is DRAC.
 use_ipmi_driver=false


### PR DESCRIPTION
This patch bumps up the default deployment timeout to 180 minutes.