### PR TITLE
Disable ceph cinder backend when the flag is set

### DIFF
--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -524,6 +524,7 @@ class Director(InfraHost):
         domain_param = "  CloudDomain:"
         rbd_backend_param = "  NovaEnableRbdBackend:"
         glance_backend_param = "  GlanceBackend:"
+        rbd_cinder_backend_param = "  CinderEnableRbdBackend:" 
         osds_per_node = 0
 
         if osd_disks:
@@ -612,6 +613,10 @@ class Director(InfraHost):
             elif line.startswith(glance_backend_param):
                 value = str(self.settings.glance_backend).lower()
                 tmp_file.write("{} {}\n".format(glance_backend_param, value))
+
+            elif line.startswith(rbd_cinder_backend_param):
+                value = str(self.settings.enable_rbd_backend).lower()
+                tmp_file.write("{} {}\n".format(rbd_cinder_backend_param, value))
 
             elif line.startswith(ceph_pools):
                 pool_str = line[len(ceph_pools):]

--- a/src/pilot/templates/dell-environment.yaml
+++ b/src/pilot/templates/dell-environment.yaml
@@ -90,7 +90,9 @@ parameter_defaults:
 
   #  devices:
   #  - /dev/sda2
-
+  
+  ## Whether to enable rbd (Ceph) backend for Cinder.
+  CinderEnableRbdBackend: true
 
   # Configure Ceph Placement Group (PG) values for the indicated pools
   CephPools: [{"name": "volumes", "pg_num": 128, "pgp_num": 128}, {"name": "vms", "pg_num": 128, "pgp_num": 128}, {"name": "images", "pg_num": 128, "pgp_num": 128}, {"name": ".rgw.buckets", "pg_num": 64, "pgp_num": 64}]


### PR DESCRIPTION
When enable_rbd_backend is set to false should not install ceph as cinder backend.

But JS is still installing ceph as cinder backend
Fixed it
 