### PR TITLE
Fix is_raid_controller

### DIFF
--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -279,12 +279,7 @@ def get_raid_controller_id(drac_client):
 
     raid_controller_ids = [
         c.id for c in disk_ctrls if drac_client.is_raid_controller(c.id)]
-    boss_controller_ids = [
-        c.id for c in disk_ctrls if drac_client.is_boss_controller(c.id)
-    ]
 
-    if boss_controller_ids:
-        raid_controller_ids.append(boss_controller_ids[0])
     number_raid_controllers = len(raid_controller_ids)
 
     if number_raid_controllers == 1:

--- a/src/pilot/client.patch
+++ b/src/pilot/client.patch
@@ -1,5 +1,5 @@
---- client.py.orig	2019-02-22 06:17:06.119881340 +0000
-+++ client.py	2019-02-22 06:22:31.234615371 +0000
+--- /usr/lib/python2.7/site-packages/dracclient/client.py	2019-04-23 19:07:27.470169786 +0000
++++ client.py	2019-04-23 19:06:54.534572120 +0000
 @@ -272,7 +272,7 @@
          state_reached = self._wait_for_host_state(
              self.client.host,
@@ -81,3 +81,30 @@
      def list_cpus(self):
          """Returns the list of CPUs
  
+@@ -962,15 +977,23 @@
+         """
+         return self._raid_mgmt.is_jbod_capable(raid_controller_fqdd)
+ 
+-    def is_raid_controller(self, raid_controller_fqdd):
+-        """Find out if object's fqdd is for a raid controller or not
++    def is_raid_controller(self, raid_controller_fqdd, raid_controllers=None):
++        """Determine if the given controller is a RAID controller
++
++        Since a BOSS controller is a type of RAID controller, this method will
++        return True for both BOSS and RAID controllers.
+ 
+         :param raid_controller_fqdd: The object's fqdd we are testing to see
+                                      if it is a raid controller or not.
++        :param raid_controllers: A list of RAIDControllers used to check for
++                                 the presence of BOSS cards.  If None, the
++                                 iDRAC will be queried for the list of
++                                 controllers.
+         :returns: boolean, True if the device is a RAID controller,
+                   False if not.
+         """
+-        return self._raid_mgmt.is_raid_controller(raid_controller_fqdd)
++        return self._raid_mgmt.is_raid_controller(raid_controller_fqdd,
++                                                  raid_controllers)
+ 
+     def is_boss_controller(self, raid_controller_fqdd):
+         """Find out if a RAID controller a BOSS card or not

--- a/src/pilot/dracclient_raid.patch
+++ b/src/pilot/dracclient_raid.patch
@@ -1,5 +1,5 @@
---- raid.py.orig	2019-02-22 12:01:15.504155374 +0000
-+++ raid.py	2019-02-20 07:14:38.810186916 +0000
+--- /usr/lib/python2.7/site-packages/dracclient/resources/raid.py	2019-04-23 19:30:47.284579280 +0000
++++ raid.py	2019-04-23 19:30:37.187395939 +0000
 @@ -34,6 +34,11 @@
  
  REVERSE_RAID_LEVELS = dict((v, k) for (k, v) in RAID_LEVELS.items())
@@ -34,9 +34,26 @@
  
      def _get_raid_controller_attr(self, drac_controller, attr_name):
          return utils.get_wsman_resource_attr(
-@@ -582,14 +591,26 @@
+@@ -572,24 +581,41 @@
+ 
+         return is_jbod_capable
+ 
+-    def is_raid_controller(self, raid_controller_fqdd):
++    def is_raid_controller(self, raid_controller_fqdd, raid_controllers=None):
+         """Find out if object's fqdd is for a raid controller or not
+ 
+         :param raid_controller_fqdd: The object's fqdd we are testing to see
+                                      if it is a raid controller or not.
++        :param raid_controllers: A list of RAIDControllers used to check for
++                                 the presence of BOSS cards.  If None, the
++                                 iDRAC will be queried for the list of
++                                 controllers.
+         :returns: boolean, True if the device is a RAID controller,
+                   False if not.
          """
-         return raid_controller_fqdd.startswith('RAID.')
+-        return raid_controller_fqdd.startswith('RAID.')
++        return raid_controller_fqdd.startswith('RAID.') or \
++            self.is_boss_controller(raid_controller_fqdd, raid_controllers)
  
 -    def is_boss_controller(self, raid_controller_fqdd):
 +    def is_boss_controller(self, raid_controller_fqdd, raid_controllers=None):
@@ -63,7 +80,21 @@
  
      def _check_disks_status(self, mode, physical_disks,
                              controllers_to_physical_disk_ids):
-@@ -763,3 +784,18 @@
+@@ -713,10 +739,11 @@
+         if not controllers_to_physical_disk_ids:
+             controllers_to_physical_disk_ids = collections.defaultdict(list)
+ 
++            all_controllers = self.list_raid_controllers()
+             for physical_d in physical_disks:
+                 # Weed out disks that are not attached to a RAID controller
+-                if (self.is_raid_controller(physical_d.controller)
+-                        or self.is_boss_controller(physical_d.controller)):
++                if self.is_raid_controller(physical_d.controller,
++                                           all_controllers):
+                     physical_disk_ids = controllers_to_physical_disk_ids[
+                         physical_d.controller]
+ 
+@@ -763,3 +790,18 @@
  
          return {'is_reboot_required': is_reboot_required,
                  'commit_required_ids': controllers}


### PR DESCRIPTION
This change patches in the changes to python-dracclient to make is_raid_controller return True for BOSS cards.  It also makes the necessary
changes to assign_role to use this change.