### PR TITLE
Add back in setting boot_mode

### DIFF
--- a/src/pilot/inspect.patch
+++ b/src/pilot/inspect.patch
@@ -1,0 +1,25 @@
+--- /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/inspect.py	2019-05-07 19:32:16.044580597 +0000
++++ inspect.py	2019-05-07 19:32:08.328439691 +0000
+@@ -23,6 +23,7 @@
+ from ironic.common import exception
+ from ironic.common.i18n import _
+ from ironic.common import states
++from ironic.common import utils
+ from ironic.drivers import base
+ from ironic.drivers.modules.drac import common as drac_common
+ from ironic import objects
+@@ -84,6 +85,14 @@
+                     [self._calculate_cpus(cpu) for cpu in cpus])
+                 properties['cpu_arch'] = 'x86_64' if cpus[0].arch64 else 'x86'
+ 
++            bios_settings = client.list_bios_settings()
++            current_capabilities = node.properties.get('capabilities', '')
++            new_capabilities = {
++                'boot_mode': bios_settings["BootMode"].current_value.lower()}
++            capabilties = utils.get_updated_capabilities(current_capabilities,
++                                                         new_capabilities)
++            properties['capabilities'] = capabilties
++
+             virtual_disks = client.list_virtual_disks()
+             root_disk = self._guess_root_disk(virtual_disks)
+             if root_disk:

--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -262,6 +262,14 @@ apply_patch "sudo patch -b -s /usr/lib/python2.7/site-packages/dracclient/resour
 sudo rm -f /usr/lib/python2.7/site-packages/dracclient/resources/raid.pyc
 sudo rm -f /usr/lib/python2.7/site-packages/dracclient/resources/raid.pyo
 
+# This hacks in a patch to out-of-band inspection to set boot_mode on the node
+# being inspected.
+echo
+echo "## Patching Ironic iDRAC driver inspect.py.."
+apply_patch "sudo patch -b -s /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/inspect.py ${HOME}/pilot/inspect.patch"
+sudo rm -f /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/inspect.pyc
+sudo rm -f /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/inspect.pyo
+
 # This hacks in a patch to create a virtual disk using realtime mode.
 # Note that this code must be here because we use this code prior to deploying
 # the director.


### PR DESCRIPTION
Setting the boot_mode has not yet made it into OSP.  This patch adds it back in.