### PR TITLE
Disable realtime RAID/JBOD conversion

### DIFF
--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -1387,6 +1387,8 @@ def change_physical_disk_state_wait(
 
     job_ids = []
     is_reboot_required = False
+    # Remove the line below to turn back on realtime conversion
+    is_reboot_required = True
     conversion_results = change_state_result['conversion_results']
     for controller_id in conversion_results.keys():
         controller_result = conversion_results[controller_id]
@@ -1397,6 +1399,8 @@ def change_physical_disk_state_wait(
         if controller_result['is_commit_required']:
             realtime = controller_result['is_reboot_required'] == \
                 RebootRequired.optional
+            # Remove the line below to turn back on realtime conversion
+            realtime = False
             job_id = drac_client.commit_pending_raid_changes(
                 controller_id,
                 reboot=False,


### PR DESCRIPTION
The patch temporarily disables RAID/JBOD conversion since it appears to not
work on some servers.