### PR TITLE
Fix deploy with low OSD count

### DIFF
--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -34,9 +34,17 @@ logger = logging.getLogger("osp_deployer")
 exitFlag = 0
 
 # Ceph pools present in a default install
-HEAVY_POOLS = ['volumes', 'images', 'vms']
-OTHER_POOLS = ['.rgw.root', 'default.rgw.control', 'default.rgw.meta',
-               'default.rgw.log', 'metrics', 'backups', '.rgw.buckets']
+HEAVY_POOLS = ['images',
+               'vms',
+               'volumes']
+OTHER_POOLS = ['.rgw.buckets',
+               '.rgw.root',
+               'backups',
+               'default.rgw.buckets.data',
+               'default.rgw.buckets.index',
+               'default.rgw.control',
+               'default.rgw.log',
+               'default.rgw.meta',
 
 # tempest configuraton file
 TEMPEST_CONF = "tempest.conf"

--- a/src/pilot/templates/dell-environment.yaml
+++ b/src/pilot/templates/dell-environment.yaml
@@ -95,7 +95,7 @@ parameter_defaults:
   CinderEnableRbdBackend: true
 
   # Configure Ceph Placement Group (PG) values for the indicated pools
-  CephPools: [{"name": "volumes", "pg_num": 128, "pgp_num": 128}, {"name": "vms", "pg_num": 128, "pgp_num": 128}, {"name": "images", "pg_num": 128, "pgp_num": 128}, {"name": ".rgw.buckets", "pg_num": 64, "pgp_num": 64}]
+  CephPools: [{"name": "volumes", "pg_num": 128, "pgp_num": 128}, {"name": "vms", "pg_num": 128, "pgp_num": 128}, {"name": "images", "pg_num": 128, "pgp_num": 128}, {"name": ".rgw.buckets", "pg_num": 64, "pgp_num": 64}, {"name": "backups", "pg_num": 64, "pgp_num": 64}, {"name": "metrics", "pg_num": 64, "pgp_num": 64}, {"name": ".rgw.root", "pg_num": 64, "pgp_num": 64}, {"name": "default.rgw.control", "pg_num": 64, "pgp_num": 64}, {"name": "default.rgw.meta", "pg_num": 64, "pgp_num": 64}, {"name": "default.rgw.log", "pg_num": 64, "pgp_num": 64}, {"name": "default.rgw.buckets.index", "pg_num": 64, "pgp_num": 64}, {"name": "default.rgw.buckets.data", "pg_num": 64, "pgp_num": 64}]
 
   CephAnsiblePlaybookVerbosity: 1
   


### PR DESCRIPTION
This patch adds in specifying all of the Ceph OSD pool sizes, which prevents
unspecified pools from defaulting to 128 PGs.  This prevents the number of
PGs from exceeding the total available when you have a low OSD count.