### PR TITLE
Take lifecycle controller out of recovery mode

### DIFF
--- a/src/pilot/client.patch
+++ b/src/pilot/client.patch
@@ -1,5 +1,5 @@
---- client_orig_14may.py.orig	2019-05-14 06:15:53.291771851 -0400
-+++ client_orig_14may.py	2019-06-04 05:49:42.711845066 -0400
+--- client.py.orig	2019-06-18 07:50:36.074404231 -0400
++++ client_new.py	2019-06-21 06:14:32.311037297 -0400
 @@ -33,7 +33,7 @@
  from dracclient import utils
  from dracclient import wsman
@@ -18,36 +18,147 @@
              retries=24)
  
          if not state_reached:
-@@ -468,7 +468,8 @@
+@@ -388,9 +388,12 @@
+             cim_name='DCIM:iDRACCardService',
+             target=idrac_fqdd)
+ 
+-    def list_lifecycle_settings(self):
++    def list_lifecycle_settings(self, by_name=False):
+         """List the Lifecycle Controller configuration settings
+ 
++        :param by_name: Controls whether returned dictionary uses Lifecycle
++                        attribute name as key. If set to False, instance_id
++                        will be used.
+         :returns: a dictionary with the Lifecycle Controller settings using its
+                   InstanceID as the key. The attributes are either
+                   LCEnumerableAttribute or LCStringAttribute objects.
+@@ -399,7 +402,49 @@
+         :raises: DRACOperationFailed on error reported back by the DRAC
+                  interface
+         """
+-        return self._lifecycle_cfg.list_lifecycle_settings()
++        return self._lifecycle_cfg.list_lifecycle_settings(by_name)
++
++    def is_lifecycle_in_recovery(self):
++        """Checks if Lifecycle Controller in recovery mode or not
++
++        This method checks the LCStatus value to determine if lifecycle
++        controller is in recovery mode by invoking GetRemoteServicesAPIStatus
++        from iDRAC.
++
++        :returns: a boolean indicating if lifecycle controller is in recovery
++        :raises: WSManRequestFailure on request failures
++        :raises: WSManInvalidResponse when receiving invalid response
++        :raises: DRACOperationFailed on error reported back by the DRAC
++                 interface
++        """
++
++        return self._lifecycle_cfg.is_lifecycle_in_recovery()
++
++    def set_lifecycle_settings(self, settings):
++        """Sets lifecycle controller configuration
++
++        It sets the pending_value parameter for each of the attributes
++        passed in. For the values to be applied, a config job must
++        be created.
++
++        :param settings: a dictionary containing the proposed values, with
++                         each key being the name of attribute and the value
++                         being the proposed value.
++        :returns: a dictionary containing:
++                 - The is_commit_required key with a boolean value indicating
++                   whether a config job must be created for the values to be
++                   applied.
++                 - The is_reboot_required key with a RebootRequired enumerated
++                   value indicating whether the server must be rebooted for the
++                   values to be applied. Possible values are true and false.
++        :raises: WSManRequestFailure on request failures
++        :raises: WSManInvalidResponse when receiving invalid response
++        :raises: DRACOperationFailed on error reported back by the DRAC
++                 interface
++        :raises: DRACUnexpectedReturnValue on return value mismatch
++        :raises: InvalidParameterValue on invalid Lifecycle attribute
++        """
++        return self._lifecycle_cfg.set_lifecycle_settings(settings)
+ 
+     def list_system_settings(self):
+         """List the System configuration settings
+@@ -468,7 +513,10 @@
                            cim_system_creation_class_name='DCIM_ComputerSystem',
                            cim_system_name='DCIM:ComputerSystem',
                            reboot=False,
 -                          start_time='TIME_NOW'):
 +                          start_time='TIME_NOW',
-+                          realtime=False):
++                          realtime=False,
++                          wait_for_idrac=True,
++                          method_name='CreateTargetedConfigJob'):
          """Creates a configuration job.
  
          In CIM (Common Information Model), weak association is used to name an
-@@ -492,6 +493,8 @@
+@@ -492,6 +540,12 @@
                             means execute immediately or None which means
                             the job will not execute until
                             schedule_job_execution is called
 +        :param realtime: Indicates if reatime mode should be used.
 +               Valid values are True and False.
++        :param wait_for_idrac: indicates whether or not to wait for the
++                               iDRAC to be ready to accept commands before
++                               issuing the command.
++        :param method_name: method of CIM object to invoke
          :returns: id of the created job
          :raises: WSManRequestFailure on request failures
          :raises: WSManInvalidResponse when receiving invalid response
-@@ -508,7 +511,8 @@
+@@ -508,7 +562,10 @@
              cim_system_creation_class_name=cim_system_creation_class_name,
              cim_system_name=cim_system_name,
              reboot=reboot,
 -            start_time=start_time)
 +            start_time=start_time,
-+            realtime=realtime)
++            realtime=realtime,
++            wait_for_idrac=wait_for_idrac,
++            method_name=method_name)
  
      def create_nic_config_job(
              self,
-@@ -784,8 +788,52 @@
+@@ -647,6 +704,37 @@
+             cim_creation_class_name='DCIM_BIOSService',
+             cim_name='DCIM:BIOSService', target=self.BIOS_DEVICE_FQDD)
+ 
++    def commit_pending_lifecycle_changes(
++            self,
++            reboot=False,
++            start_time='TIME_NOW'):
++        """Applies all pending changes on Lifecycle by creating a config job
++
++        :param reboot: indicates whether a RebootJob should also be
++                       created or not
++        :param start_time: start time for job execution in format
++                           yyyymmddhhmmss, the string 'TIME_NOW' which
++                           means execute immediately or None which means
++                           the job will not execute until
++                           schedule_job_execution is called
++        :returns: id of the created job
++        :raises: WSManRequestFailure on request failures
++        :raises: WSManInvalidResponse when receiving invalid response
++        :raises: DRACOperationFailed on error reported back by the DRAC
++                 interface, including start_time being in the past or
++                 badly formatted start_time
++        :raises: DRACUnexpectedReturnValue on return value mismatch
++        """
++        return self._job_mgmt.create_config_job(
++            resource_uri=uris.DCIM_LCService,
++            cim_creation_class_name='DCIM_LCService',
++            cim_name='DCIM:LCService',
++            target='',
++            reboot=reboot,
++            start_time=start_time,
++            wait_for_idrac=False,
++            method_name='CreateConfigJob')
++
+     def get_lifecycle_controller_version(self):
+         """Returns the Lifecycle controller version
+ 
+@@ -784,8 +872,52 @@
          """
          return self._raid_mgmt.delete_virtual_disk(virtual_disk)
  
@@ -101,7 +212,7 @@
          """Applies all pending changes on a RAID controller
  
           ...by creating a config job.
-@@ -798,6 +846,8 @@
+@@ -798,6 +930,8 @@
                 means execute immediately or None which means
                 the job will not execute until
                 schedule_job_execution is called
@@ -110,7 +221,7 @@
          :returns: id of the created job
          :raises: WSManRequestFailure on request failures
          :raises: WSManInvalidResponse when receiving invalid response
-@@ -811,7 +861,8 @@
+@@ -811,7 +945,8 @@
              cim_name='DCIM:RAIDService',
              target=raid_controller,
              reboot=reboot,
@@ -120,7 +231,7 @@
  
      def abandon_pending_raid_changes(self, raid_controller):
          """Deletes all pending changes on a RAID controller
-@@ -830,6 +881,14 @@
+@@ -830,6 +965,14 @@
              cim_creation_class_name='DCIM_RAIDService',
              cim_name='DCIM:RAIDService', target=raid_controller)
  
@@ -135,7 +246,7 @@
      def list_cpus(self):
          """Returns the list of CPUs
  
-@@ -962,15 +1021,23 @@
+@@ -962,53 +1105,71 @@
          """
          return self._raid_mgmt.is_jbod_capable(raid_controller_fqdd)
  
@@ -160,9 +271,80 @@
 +        return self._raid_mgmt.is_raid_controller(raid_controller_fqdd,
 +                                                  raid_controllers)
  
-     def is_boss_controller(self, raid_controller_fqdd):
+-    def is_boss_controller(self, raid_controller_fqdd):
++    def is_boss_controller(self, raid_controller_fqdd, raid_controllers=None):
          """Find out if a RAID controller a BOSS card or not
-@@ -1170,11 +1237,11 @@
+ 
+         :param raid_controller_fqdd: The object's fqdd we are testing to see
+                                      if it is a BOSS card or not.
++        :param raid_controllers: A list of RAIDController to scan for presence
++                                 of BOSS card, if None the drac will be queried
++                                 for the list of controllers which will then be
++                                 scanned.
+         :returns: boolean, True if the device is a BOSS card, False if not.
++        :raises: WSManRequestFailure on request failures
++        :raises: WSManInvalidResponse when receiving invalid response
++        :raises: DRACOperationFailed on error reported back by the DRAC
++                 interface
+         """
+-        return self._raid_mgmt.is_boss_controller(raid_controller_fqdd)
++        return self._raid_mgmt.is_boss_controller(raid_controller_fqdd,
++                                                  raid_controllers)
+ 
+     def change_physical_disk_state(self, mode,
+                                    controllers_to_physical_disk_ids=None):
+-        """Convert disks RAID status and return a list of controller IDs
++        """Convert disks RAID status
+ 
+-        Builds a list of controller ids that have had disks converted to the
+-        specified RAID status by:
+-        - Examining all the disks in the system and filtering out any that are
+-          not attached to a RAID/BOSS controller.
+-        - Inspect the controllers' disks to see if there are any that need to
+-          be converted, if so convert them. If a disk is already in the desired
+-          status the disk is ignored. Also check for failed or unknown disk
+-          statuses and raise an exception where appropriate.
+-        - Return a list of controller IDs for controllers whom have had any of
+-          their disks converted, and whether a reboot is required.
++        This method intelligently converts the requested physical disks from
++        RAID to JBOD or vice versa.  It does this by only converting the
++        disks that are not already in the correct state.
+ 
+-        The caller typically should then create a config job for the list of
+-        controllers returned to finalize the RAID configuration.
+-
+-        :param mode: constants.RaidStatus enumeration used to determine what
+-                     raid status to check for.
++        :param mode: constants.RaidStatus enumeration that indicates the mode
++                     to change the disks to.
+         :param controllers_to_physical_disk_ids: Dictionary of controllers and
+-               corresponding disk ids we are inspecting and creating jobs for
+-               when needed.
+-        :returns: a dict containing the following key/values:
++               corresponding disk ids to convert to the requested mode.
++        :returns: a dictionary containing:
++                  - conversion_results, a dictionary that maps controller ids
++                    to the conversion results for that controller.  The
++                    conversion results are a dict that contains:
++                    - The is_commit_required key with the value always set to
++                      True indicating that a config job must be created to
++                      complete disk conversion.
++                    - The is_reboot_required key with a RebootRequired
++                      enumerated value indicating whether the server must be
++                      rebooted to complete disk conversion.
++                  Also contained in the main dict are the following key/values,
++                  which are deprecated, should not be used, and will be removed
++                  in a future release:
+                   - is_reboot_required, a boolean stating whether a reboot is
+-                  required or not.
++                    required or not.
+                   - commit_required_ids, a list of controller ids that will
+-                  need to commit their pending RAID changes via a config job.
++                    need to commit their pending RAID changes via a config job.
+         :raises: DRACOperationFailed on error reported back by the DRAC and the
+                  exception message does not contain NOT_SUPPORTED_MSG constant.
+         :raises: Exception on unknown error.
+@@ -1170,11 +1331,11 @@
                               expected_return_value=utils.RET_SUCCESS,
                               wait_for_idrac=False)
  

--- a/src/pilot/config_idrac.py
+++ b/src/pilot/config_idrac.py
@@ -541,7 +541,7 @@ def reset_idrac(drac_client, ip_service_tag):
     drac_client.reset_idrac(wait=True)
 
 
-def get_lifecycle_out_of_recovery(drac_client, ip_service_tag):
+def take_lifecycle_out_of_recovery(drac_client, ip_service_tag):
     LOG.info("Setting lifecycle settings on {}".format(ip_service_tag))
     settings = {'Lifecycle Controller State': 'Enabled'}
     drac_client.set_lifecycle_settings(settings)
@@ -591,7 +591,7 @@ def config_idrac(instack_lock,
     LOG.info("Checking if Lifecycle Controller is in recovery or not")
     if drac_client.is_lifecycle_in_recovery():
         LOG.info("Lifecycle Controller is in recovery mode")
-        get_lifecycle_out_of_recovery(drac_client, ip_service_tag)
+        take_lifecycle_out_of_recovery(drac_client, ip_service_tag)
     else:
         LOG.info("Lifecycle Controller is not in recovery mode")
 

--- a/src/pilot/config_idrac.py
+++ b/src/pilot/config_idrac.py
@@ -541,6 +541,22 @@ def reset_idrac(drac_client, ip_service_tag):
     drac_client.reset_idrac(wait=True)
 
 
+def get_lifecycle_out_of_recovery(drac_client, ip_service_tag):
+    LOG.info("Setting lifecycle settings on {}".format(ip_service_tag))
+    settings = {'Lifecycle Controller State': 'Enabled'}
+    drac_client.set_lifecycle_settings(settings)
+
+    LOG.info("Waiting for lifecycle controller to get out of"
+             "recovery mode")
+    job_id = drac_client.commit_pending_lifecycle_changes(reboot=False)
+    job_succeeded = wait_for_jobs_to_complete(
+        [job_id], drac_client, ip_service_tag)
+
+    if not job_succeeded:
+        raise RuntimeError("An error occurred while configuring "
+                           "the iDRAC on {}".format(ip_service_tag))
+
+
 def config_idrac(instack_lock,
                  ip_service_tag,
                  node_definition=Constants.INSTACKENV_FILENAME,
@@ -571,6 +587,13 @@ def config_idrac(instack_lock,
         return
 
     drac_client = client.DRACClient(drac_ip, drac_user, drac_password)
+
+    LOG.info("Checking if Lifecycle Controller is in recovery or not")
+    if drac_client.is_lifecycle_in_recovery():
+        LOG.info("Lifecycle Controller is in recovery mode")
+        get_lifecycle_out_of_recovery(drac_client, ip_service_tag)
+    else:
+        LOG.info("Lifecycle Controller is not in recovery mode")
 
     reset_idrac(drac_client, ip_service_tag)
 

--- a/src/pilot/config_idrac.py
+++ b/src/pilot/config_idrac.py
@@ -546,15 +546,15 @@ def get_lifecycle_out_of_recovery(drac_client, ip_service_tag):
     settings = {'Lifecycle Controller State': 'Enabled'}
     drac_client.set_lifecycle_settings(settings)
 
-    LOG.info("Waiting for lifecycle controller to get out of"
+    LOG.info("Waiting for lifecycle controller to get out of "
              "recovery mode")
     job_id = drac_client.commit_pending_lifecycle_changes(reboot=False)
     job_succeeded = wait_for_jobs_to_complete(
         [job_id], drac_client, ip_service_tag)
 
     if not job_succeeded:
-        raise RuntimeError("An error occurred while configuring "
-                           "the iDRAC on {}".format(ip_service_tag))
+        raise RuntimeError("An error occurred while taking the iDRAC on "
+                           "{} out of recovery mode".format(ip_service_tag))
 
 
 def config_idrac(instack_lock,

--- a/src/pilot/job.patch
+++ b/src/pilot/job.patch
@@ -1,16 +1,39 @@
---- /usr/lib/python2.7/site-packages/dracclient/resources/job.py	2018-09-19 09:11:40.000000000 +0000
-+++ job.py	2018-10-31 21:09:31.289000000 +0000
-@@ -117,7 +117,8 @@
+--- job.py.orig	2018-11-26 15:48:07.000000000 -0600
++++ job.py	2019-06-20 01:46:25.455571796 -0500
+@@ -117,7 +117,10 @@
                            cim_system_creation_class_name='DCIM_ComputerSystem',
                            cim_system_name='DCIM:ComputerSystem',
                            reboot=False,
 -                          start_time='TIME_NOW'):
 +                          start_time='TIME_NOW',
-+                          realtime=False):
++                          realtime=False,
++                          wait_for_idrac=True,
++                          method_name='CreateTargetedConfigJob'):
          """Creates a config job
  
          In CIM (Common Information Model), weak association is used to name an
-@@ -157,7 +158,10 @@
+@@ -142,6 +145,12 @@
+                            but will not start execution until
+                            schedule_job_execution is called with the returned
+                            job id.
++        :param realtime: Indicates if reatime mode should be used.
++               Valid values are True and False. Default value is False.
++        :param wait_for_idrac: indicates whether or not to wait for the
++                               iDRAC to be ready to accept commands before
++                               issuing the command.
++        :param method_name: method of CIM object to invoke
+         :returns: id of the created job
+         :raises: WSManRequestFailure on request failures
+         :raises: WSManInvalidResponse when receiving invalid response
+@@ -149,7 +158,6 @@
+                  interface
+         :raises: DRACUnexpectedReturnValue on return value mismatch
+         """
+-
+         selectors = {'SystemCreationClassName': cim_system_creation_class_name,
+                      'SystemName': cim_system_name,
+                      'CreationClassName': cim_creation_class_name,
+@@ -157,15 +165,19 @@
  
          properties = {'Target': target}
  
@@ -22,3 +45,15 @@
              properties['RebootJobType'] = '3'
  
          if start_time is not None:
+             properties['ScheduledStartTime'] = start_time
+ 
+-        doc = self.client.invoke(resource_uri, 'CreateTargetedConfigJob',
+-                                 selectors, properties,
+-                                 expected_return_value=utils.RET_CREATED)
++        doc = self.client.invoke(resource_uri, method_name,
++                                     selectors, properties,
++                                     expected_return_value=utils.RET_CREATED,
++                                     wait_for_idrac=wait_for_idrac)
+ 
+         return self._get_job_id(doc)
+ 

--- a/src/pilot/lifecycle_controller.patch
+++ b/src/pilot/lifecycle_controller.patch
@@ -1,0 +1,173 @@
+--- /usr/lib/python2.7/site-packages/dracclient/resources/lifecycle_controller.py	2019-06-18 06:56:36.818471872 -0400
++++ lifecycle_controller.py	2019-06-17 03:15:33.796000360 -0400
+@@ -14,7 +14,6 @@
+ from dracclient import constants
+ from dracclient.resources import uris
+ from dracclient import utils
+-from dracclient import wsman
+ 
+ 
+ class LifecycleControllerManagement(object):
+@@ -43,47 +42,6 @@
+         return tuple(map(int, (lc_version_str.split('.'))))
+ 
+ 
+-class LCConfiguration(object):
+-
+-    def __init__(self, client):
+-        """Creates LifecycleControllerManagement object
+-
+-        :param client: an instance of WSManClient
+-        """
+-        self.client = client
+-
+-    def list_lifecycle_settings(self):
+-        """List the LC configuration settings
+-
+-        :returns: a dictionary with the LC settings using InstanceID as the
+-                  key. The attributes are either LCEnumerableAttribute,
+-                  LCStringAttribute or LCIntegerAttribute objects.
+-        :raises: WSManRequestFailure on request failures
+-        :raises: WSManInvalidResponse when receiving invalid response
+-        :raises: DRACOperationFailed on error reported back by the DRAC
+-                 interface
+-        """
+-        result = {}
+-        namespaces = [(uris.DCIM_LCEnumeration, LCEnumerableAttribute),
+-                      (uris.DCIM_LCString, LCStringAttribute)]
+-        for (namespace, attr_cls) in namespaces:
+-            attribs = self._get_config(namespace, attr_cls)
+-            result.update(attribs)
+-        return result
+-
+-    def _get_config(self, resource, attr_cls):
+-        result = {}
+-
+-        doc = self.client.enumerate(resource)
+-
+-        items = doc.find('.//{%s}Items' % wsman.NS_WSMAN)
+-        for item in items:
+-            attribute = attr_cls.parse(item)
+-            result[attribute.instance_id] = attribute
+-
+-        return result
+-
+-
+ class LCAttribute(object):
+     """Generic LC attribute class"""
+ 
+@@ -162,6 +120,17 @@
+                    lifecycle_attr.current_value, lifecycle_attr.pending_value,
+                    lifecycle_attr.read_only, possible_values)
+ 
++    def validate(self, new_value):
++        """Validates new value"""
++
++        if str(new_value) not in self.possible_values:
++            msg = ("Attribute '%(attr)s' cannot be set to value '%(val)s'."
++                   " It must be in %(possible_values)r.") % {
++                       'attr': self.name,
++                       'val': new_value,
++                       'possible_values': self.possible_values}
++            return msg
++
+ 
+ class LCStringAttribute(LCAttribute):
+     """String LC attribute class"""
+@@ -200,3 +169,96 @@
+         return cls(lifecycle_attr.name, lifecycle_attr.instance_id,
+                    lifecycle_attr.current_value, lifecycle_attr.pending_value,
+                    lifecycle_attr.read_only, min_length, max_length)
++
++
++class LCConfiguration(object):
++
++    NAMESPACES = [(uris.DCIM_LCEnumeration, LCEnumerableAttribute),
++                  (uris.DCIM_LCString, LCStringAttribute)]
++
++    def __init__(self, client):
++        """Creates LifecycleControllerManagement object
++
++        :param client: an instance of WSManClient
++        """
++        self.client = client
++
++    def list_lifecycle_settings(self, by_name=False):
++        """List the LC configuration settings
++
++        :param by_name: Controls whether returned dictionary uses Lifecycle
++                        attribute name or instance_id as key.
++        :returns: a dictionary with the LC settings using InstanceID as the
++                  key. The attributes are either LCEnumerableAttribute,
++                  LCStringAttribute or LCIntegerAttribute objects.
++        :raises: WSManRequestFailure on request failures
++        :raises: WSManInvalidResponse when receiving invalid response
++        :raises: DRACOperationFailed on error reported back by the DRAC
++                 interface
++        """
++        return utils.list_settings(self.client, self.NAMESPACES, by_name)
++
++    def is_lifecycle_in_recovery(self):
++        """Check if Lifecycle Controller in recovery mode or not
++
++        This method checks the LCStatus value to determine if lifecycle
++        controller is in recovery mode by invoking GetRemoteServicesAPIStatus
++        from iDRAC.
++
++        :returns: a boolean indicating if lifecycle controller is in recovery
++        :raises: WSManRequestFailure on request failures
++        :raises: WSManInvalidResponse when receiving invalid response
++        :raises: DRACOperationFailed on error reported back by the DRAC
++                 interface
++        """
++
++        selectors = {'SystemCreationClassName': 'DCIM_ComputerSystem',
++                     'SystemName': 'DCIM:ComputerSystem',
++                     'CreationClassName': 'DCIM_LCService',
++                     'Name': 'DCIM:LCService'}
++
++        doc = self.client.invoke(uris.DCIM_LCService,
++                                 'GetRemoteServicesAPIStatus',
++                                 selectors,
++                                 {},
++                                 expected_return_value=utils.RET_SUCCESS,
++                                 wait_for_idrac=False)
++
++        lc_status = utils.find_xml(doc,
++                                   'LCStatus',
++                                   uris.DCIM_LCService).text
++
++        return lc_status == constants.LC_IN_RECOVERY
++
++    def set_lifecycle_settings(self, settings):
++        """Sets the Lifecycle Controller configuration
++
++        It sets the pending_value parameter for each of the attributes
++        passed in. For the values to be applied, a config job must
++        be created.
++
++        :param settings: a dictionary containing the proposed values, with
++                         each key being the name of attribute and the value
++                         being the proposed value.
++        :returns: a dictionary containing:
++                 - The is_commit_required key with a boolean value indicating
++                   whether a config job must be created for the values to be
++                   applied.
++                 - The is_reboot_required key with a RebootRequired enumerated
++                   value indicating whether the server must be rebooted for the
++                   values to be applied.  Possible values are true and false.
++        :raises: WSManRequestFailure on request failures
++        :raises: WSManInvalidResponse when receiving invalid response
++        :raises: DRACOperationFailed on error reported back by the DRAC
++                 interface
++        """
++
++        return utils.set_settings('Lifecycle',
++                                  self.client,
++                                  self.NAMESPACES,
++                                  settings,
++                                  uris.DCIM_LCService,
++                                  "DCIM_LCService",
++                                  "DCIM:LCService",
++                                  '',
++                                  wait_for_idrac=False)

--- a/src/pilot/utils.patch
+++ b/src/pilot/utils.patch
@@ -1,0 +1,83 @@
+--- /usr/lib/python2.7/site-packages/dracclient/utils.py	2019-06-21 02:53:08.048945005 -0400
++++ utils_new.py	2019-06-20 07:48:57.191489514 -0400
+@@ -251,7 +251,7 @@
+ 
+ 
+ def list_settings(client, namespaces, by_name=True, fqdd_filter=None,
+-                  name_formatter=None):
++                  name_formatter=None, wait_for_idrac=True):
+     """List the configuration settings
+ 
+     :param client: an instance of WSManClient.
+@@ -263,6 +263,9 @@
+     :param name_formatter: a method used to format the keys in the
+                            returned dictionary.  By default,
+                            attribute.name will be used.
++    :param wait_for_idrac: indicates whether or not to wait for the
++                           iDRAC to be ready to accept commands before
++                           issuing the command.
+     :returns: a dictionary with the settings using name or instance_id as
+               the key.
+     :raises: WSManRequestFailure on request failures
+@@ -274,7 +277,7 @@
+     result = {}
+     for (namespace, attr_cls) in namespaces:
+         attribs = _get_config(client, namespace, attr_cls, by_name,
+-                              fqdd_filter, name_formatter)
++                              fqdd_filter, name_formatter, wait_for_idrac)
+         if not set(result).isdisjoint(set(attribs)):
+             raise exceptions.DRACOperationFailed(
+                 drac_messages=('Colliding attributes %r' % (
+@@ -284,10 +287,10 @@
+ 
+ 
+ def _get_config(client, resource, attr_cls, by_name, fqdd_filter,
+-                name_formatter):
++                name_formatter, wait_for_idrac):
+     result = {}
+ 
+-    doc = client.enumerate(resource)
++    doc = client.enumerate(resource, wait_for_idrac=wait_for_idrac)
+     items = doc.find('.//{%s}Items' % wsman.NS_WSMAN)
+ 
+     for item in items:
+@@ -316,7 +319,8 @@
+                  cim_name,
+                  target,
+                  name_formatter=None,
+-                 include_commit_required=False):
++                 include_commit_required=False,
++                 wait_for_idrac=True):
+     """Generically handles setting various types of settings on the iDRAC
+ 
+     This method pulls the current list of settings from the iDRAC then compares
+@@ -339,6 +343,9 @@
+                            attribute.name will be used.
+     :parm include_commit_required: Indicates if the deprecated commit_required
+                                    should be returned in the result.
++    :param wait_for_idrac: indicates whether or not to wait for the
++                           iDRAC to be ready to accept commands before issuing
++                           the command
+     :returns: a dictionary containing:
+              - The commit_required key with a boolean value indicating
+                whether a config job must be created for the values to be
+@@ -361,7 +368,8 @@
+     """
+ 
+     current_settings = list_settings(client, namespaces, by_name=True,
+-                                     name_formatter=name_formatter)
++                                     name_formatter=name_formatter,
++                                     wait_for_idrac=wait_for_idrac)
+ 
+     unknown_keys = set(new_settings) - set(current_settings)
+     if unknown_keys:
+@@ -428,7 +436,8 @@
+                   'AttributeValue': [new_settings[attr] for attr
+                                      in attrib_names]}
+     doc = client.invoke(resource_uri, 'SetAttributes',
+-                        selectors, properties)
++                        selectors, properties,
++                        wait_for_idrac=wait_for_idrac)
+ 
+     return build_return_dict(doc, resource_uri,
+                              include_commit_required=include_commit_required)


### PR DESCRIPTION
@cdearborn @rpioso @digambar15 
modified config_idrac.py in JetStream calling directly into python-dracclient to check if a node is in recovery mode and take it out of recovery mode if necessary.
And also created monkey patch for client.py, job.py, utils.py and lifecycle_controller.py