### PR TITLE
Fix PXE booting issues during deployment

### DIFF
--- a/src/pilot/inspect.patch
+++ b/src/pilot/inspect.patch
@@ -1,5 +1,5 @@
---- /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/inspect.py	2019-05-07 19:32:16.044580597 +0000
-+++ inspect.py	2019-05-07 19:32:08.328439691 +0000
+--- inspect.py	2019-07-17 17:06:25.100950787 +0000
++++ inspect.py.new	2019-07-17 17:06:12.981728624 +0000
 @@ -23,6 +23,7 @@
  from ironic.common import exception
  from ironic.common.i18n import _
@@ -23,3 +23,70 @@
              virtual_disks = client.list_virtual_disks()
              root_disk = self._guess_root_disk(virtual_disks)
              if root_disk:
+@@ -119,10 +128,17 @@
+                       {'node_uuid': node.uuid, 'error': exc})
+             raise exception.HardwareInspectionFailure(error=exc)
+ 
++        pxe_dev_nics = self._get_pxe_dev_nics(client, nics, node)
++        if pxe_dev_nics is None:
++            LOG.warning('No PXE enabled NIC was found for node '
++                        '%(node_uuid)s.', {'node_uuid': node.uuid})
++
+         for nic in nics:
+             try:
+                 port = objects.Port(task.context, address=nic.mac,
+-                                    node_id=node.id)
++                                    node_id=node.id,
++                                    pxe_enabled=(nic.id in pxe_dev_nics))
++
+                 port.create()
+                 LOG.info('Port created with MAC address %(mac)s '
+                          'for node %(node_uuid)s during inspection',
+@@ -161,3 +177,47 @@
+             return cpu.cores * 2
+         else:
+             return cpu.cores
++
++    def _get_pxe_dev_nics(self, client, nics, node):
++        """Get a list of pxe device interfaces.
++
++        :param client: Dracclient to list the bios settings and nics
++        :param nics: list of nics
++
++        :returns: Returns list of pxe device interfaces.
++        """
++        pxe_dev_nics = []
++        pxe_params = ["PxeDev1EnDis", "PxeDev2EnDis",
++                      "PxeDev3EnDis", "PxeDev4EnDis"]
++        pxe_nics = ["PxeDev1Interface", "PxeDev2Interface",
++                    "PxeDev3Interface", "PxeDev4Interface"]
++
++        try:
++            bios_settings = client.list_bios_settings()
++        except drac_exceptions.BaseClientException as exc:
++            LOG.error('DRAC driver failed to list bios settings '
++                      'for %(node_uuid)s. Reason: %(error)s.',
++                      {'node_uuid': node.uuid, 'error': exc})
++            raise exception.HardwareInspectionFailure(error=exc)
++
++        if bios_settings["BootMode"].current_value == "Uefi":
++            for param, nic in zip(pxe_params, pxe_nics):
++                if param in bios_settings and bios_settings[
++                        param].current_value == "Enabled":
++                    pxe_dev_nics.append(
++                        bios_settings[nic].current_value)
++        elif bios_settings["BootMode"].current_value == "Bios":
++            for nic in nics:
++                try:
++                    nic_cap = client.list_nic_settings(nic_id=nic.id)
++                except drac_exceptions.BaseClientException as exc:
++                    LOG.error('DRAC driver failed to list nic settings '
++                              'for %(node_uuid)s. Reason: %(error)s.',
++                              {'node_uuid': node.uuid, 'error': exc})
++                    raise exception.HardwareInspectionFailure(error=exc)
++
++                if ("LegacyBootProto" in nic_cap and nic_cap[
++                        'LegacyBootProto'].current_value == "PXE"):
++                    pxe_dev_nics.append(nic.id)
++
++        return pxe_dev_nics


### PR DESCRIPTION
This patch monkey patches in the fix for setting pxe_enabled on ironic ports
during OOB introspection.