### PR TITLE
Support for BOSS+PERC in 14G storage nodes

### DIFF
--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -420,8 +420,8 @@ def define_storage_logical_disks(drac_client, raid_controllers):
                 raid_cntlr_physical_disks[boss_controller[0]],
                 drac_client, boss_controller[0])
         else:
-            LOG.critical("At least 2 drives controlled by the same RAID "
-                         "controller are needed to configure a RAID 1")
+            LOG.critical("The BOSS card has only 1 SSD. "
+                         "2 SSDs are needed to configure a RAID 1")
             return None
     else:
         raid_controller = [cntrl for cntrl in raid_controllers
@@ -1049,17 +1049,10 @@ def get_drives(drac_client):
 
     if physical_disks:
         for pd_id in physical_disks:
-            # Eliminate physical disks that in a state other than non-RAID
+            # Eliminate physical disks in a state other than non-RAID
+            # including failed disks
             if physical_disks[pd_id].raid_status != "non-RAID":
                 LOG.info("Skipping disk {id}, because it has a RAID status of "
-                         "{raid_status}".format(
-                             id=physical_disks[pd_id].id,
-                             raid_status=physical_disks[pd_id].raid_status))
-                continue
-
-            # Eliminate physical disks that have a failed status
-            if physical_disks[pd_id].raid_status == "failed":
-                LOG.info("Skipping disk {id}, because it has a status of "
                          "{raid_status}".format(
                              id=physical_disks[pd_id].id,
                              raid_status=physical_disks[pd_id].raid_status))

--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -1050,9 +1050,16 @@ def get_drives(drac_client):
     if physical_disks:
         for pd_id in physical_disks:
             # Eliminate physical disks that in a state other than non-RAID
-            if physical_disks[pd_id].raid_status != "non-RAID" and \
-                    physical_disks[pd_id].raid_status == "failed":
+            if physical_disks[pd_id].raid_status != "non-RAID":
                 LOG.info("Skipping disk {id}, because it has a RAID status of "
+                         "{raid_status}".format(
+                             id=physical_disks[pd_id].id,
+                             raid_status=physical_disks[pd_id].raid_status))
+                continue
+
+            # Eliminate physical disks that have a failed status
+            if physical_disks[pd_id].raid_status == "failed":
+                LOG.info("Skipping disk {id}, because it has a status of "
                          "{raid_status}".format(
                              id=physical_disks[pd_id].id,
                              raid_status=physical_disks[pd_id].raid_status))

--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -1143,7 +1143,12 @@ def get_by_path_device_name(physical_disk, controllers):
 
 
 def get_pci_bus_number(controller):
-    return controller.bus.lower()
+    if controller.model.startswith("PERC H730") and \
+           len(controller.bus.lower()) == 1:
+        pci_bus_number = '0' + controller.bus.lower()
+    else:
+        pci_bus_number = controller.bus.lower()
+    return pci_bus_number
 
 
 def get_fqdd(doc, namespace):


### PR DESCRIPTION
Following features will be implemented as part of this PR -

1. PERC H740P is supported and able to create OSD's successfully.
2. No more need to add osd_disks in .properties file as ceph_osd_config.yaml is generating as expected and Ceph is also picking up all the devices successfully as part of OSD creation.
3. Two controllers (BOSS + PERC) are supported in 14G Storage nodes.

Note - Current testing is done only against PERC H740P controller. Soon we will perform testing both the controllers.