### PR TITLE
create logical disks with physical disks w.r.t free_size_mb

### DIFF
--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -590,7 +590,7 @@ def bin_physical_disks_by_size_gb(physical_disks, media_type_filter=None):
         # Apply media type filter, if present.
         if (media_type_filter is None or
                 physical_disk.media_type == media_type_filter):
-            disks_by_size[physical_disk.size_mb / 1024].append(physical_disk)
+            disks_by_size[physical_disk.free_size_mb / 1024].append(physical_disk)
 
     return disks_by_size
 


### PR DESCRIPTION
This patch is a Fix to perform drives conversion from RAID to JBOD and vice versa in realtime.(PS : [CES-6956](https://jira.dellemc-community.org/browse/CES-6956) 
Due to current firmware issue, ironic is not able  to create configuration job in realtime.
For more details, i have raised a bug (PS: [CES-10788](https://jira.dellemc-community.org/browse/CES-10788).
