### PR TITLE
Enabled realtime support for drives conversion in JBOD/RAID

### DIFF
--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -1383,8 +1383,7 @@ def change_physical_disk_state_wait(
 
     job_ids = []
     is_reboot_required = False
-    # Remove the line below to turn back on realtime conversion
-    is_reboot_required = True
+
     conversion_results = change_state_result['conversion_results']
     for controller_id in conversion_results.keys():
         controller_result = conversion_results[controller_id]
@@ -1395,8 +1394,6 @@ def change_physical_disk_state_wait(
         if controller_result['is_commit_required']:
             realtime = controller_result['is_reboot_required'] == \
                 RebootRequired.optional
-            # Remove the line below to turn back on realtime conversion
-            realtime = False
             job_id = drac_client.commit_pending_raid_changes(
                 controller_id,
                 reboot=False,


### PR DESCRIPTION
Hi @cdearborn ,
I have completed deployment on 13G(R145) till assign_role(and it executing further to `Installing the overcloud`) with latest pull successfully by removing variable which disables realtime drives conversion.

Please take a look.
Thanks