### PR TITLE
Fix SAH install

### DIFF
--- a/src/mgmt/osp-sah.ks
+++ b/src/mgmt/osp-sah.ks
@@ -595,7 +595,7 @@ echo "POST: upgrade setuptools"
 pip install --upgrade setuptools
 pip install paramiko
 pip install selenium
-pip install cryptography==2.4.2
+pip install cryptography
 echo "POST: Done installing extra packages"
 
 echo 'export PYTHONPATH=/usr/bin/python:/lib/python2.7:/lib/python2.7/site-packages:/root/JetPack/src/deploy/' >> /root/.bashrc


### PR DESCRIPTION
This patch merges in a fix from JS/master that fixes a problem
where the wrong version of cryptography was being installed.