### PR TITLE
Kickstart Changes for RHEL8

### DIFF
--- a/src/mgmt/osp-sah.ks
+++ b/src/mgmt/osp-sah.ks
@@ -67,7 +67,6 @@ eula --agreed
 @virtualization-client
 @virtualization-hypervisor
 @virtualization-tools
-chrony
 %end
 
 
@@ -374,7 +373,7 @@ done
 
 
 echo "allow ${NTPSettings}" >> /etc/chrony.conf
-echo "server  127.127.1.0 # local clock" >> /etc/chrony.conf
+echo "server 127.127.1.0 # local clock" >> /etc/chrony.conf
 
 
 # Configure Bonding and VLANS
@@ -590,10 +589,7 @@ fi
          subscription-manager attach --auto ${ProxyInfo}
          )
 
-subscription-manager repos ${ProxyInfo} '--disable=*' --enable=rhel-7-server-rpms --enable=rhel-7-server-optional-rpms
-
-systemctl disable NetworkManager
-systemctl disable chronyd
+subscription-manager repos ${ProxyInfo} '--disable=*' --enable=rhel-8-for-x86_64-baseos-rpms --enable=rhel-8-for-x86_64-appstream-rpms
 
 mkdir -p /store/data/images
 mkdir -p /store/data/iso

--- a/src/mgmt/osp-sah.ks
+++ b/src/mgmt/osp-sah.ks
@@ -53,11 +53,11 @@ firstboot --disable
 eula --agreed
 
 %packages
+@standard
 @python36
 @gnome-desktop
 @internet-browser
-@x11
-@dns-server
+@network-server
 @ftp-server
 @file-server
 @network-file-system-client
@@ -67,7 +67,6 @@ eula --agreed
 @virtualization-client
 @virtualization-hypervisor
 @virtualization-tools
-dhcp
 chrony
 %end
 

--- a/src/mgmt/osp-sah.ks
+++ b/src/mgmt/osp-sah.ks
@@ -52,6 +52,7 @@ firstboot --disable
 eula --agreed
 
 %packages
+@python36
 @gnome-desktop
 @internet-browser
 @x11
@@ -603,7 +604,7 @@ mkdir -p /store/data/images
 mkdir -p /store/data/iso
 
 echo "POST: Install other rerquired packages, paramiko, ..."
-yum install -y gcc libffi-devel python-devel openssl-devel python-setuptools ipmitool tmux git
+yum install -y gcc libffi-devel openssl-devel ipmitool tmux git
 
 echo "POST: get and install pip"
 curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
@@ -616,7 +617,7 @@ pip install selenium
 pip install cryptography
 echo "POST: Done installing extra packages"
 
-echo 'export PYTHONPATH=/usr/bin/python:/lib/python2.7:/lib/python2.7/site-packages:/root/JetPack/src/deploy/' >> /root/.bashrc
+echo 'export PYTHONPATH=/usr/bin/python:/lib/python3.6:/lib/python3.6/site-packages:/root/JetPack/src/deploy/' >> /root/.bashrc
 
 # chvt 1
 

--- a/src/mgmt/osp-sah.ks
+++ b/src/mgmt/osp-sah.ks
@@ -48,6 +48,7 @@ auth --enableshadow --passalgo=sha512
 
 skipx
 text
+firewall --disable
 firstboot --disable
 eula --agreed
 
@@ -68,8 +69,6 @@ eula --agreed
 @virtualization-tools
 dhcp
 chrony
--firewalld
-system-config-firewall-base
 %end
 
 
@@ -595,7 +594,6 @@ fi
 subscription-manager repos ${ProxyInfo} '--disable=*' --enable=rhel-7-server-rpms --enable=rhel-7-server-optional-rpms
 
 systemctl disable NetworkManager
-systemctl disable firewalld
 systemctl disable chronyd
 
 mkdir -p /store/data/images


### PR DESCRIPTION
Replaced python 2.7 with python 3.6
Firewall service is included by default in rhel8 and disabled in kickstart
List of Packages to be installed is updated accordingly
NTP configurations are replaced by chrony configurations