### PR TITLE
adding monkey patch for cleaning steps of management interface

### DIFF
--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -301,6 +301,14 @@ sudo rm -f /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/raid.pyc
 sudo rm -f /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/raid.pyo
 echo "## Done."
 
+# This hacks in a patch to add clean steps in management interface.
+echo
+echo "## Patching Ironic iDRAC driver management.py..."
+apply_patch "sudo patch -b -s /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/management.py ${HOME}/pilot/management.patch"
+sudo rm -f /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/management.pyc
+sudo rm -f /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/management.pyo
+echo "## Done."
+
 # This hacks in a patch to filter out all non-printable characters during WSMAN
 # enumeration.
 # Note that this code must be here because we use this code prior to deploying

--- a/src/pilot/management.patch
+++ b/src/pilot/management.patch
@@ -1,0 +1,96 @@
+--- management.py	2019-10-17 06:45:23.707427260 -0400
++++ management_new.py	2019-10-17 06:52:49.445658562 -0400
+@@ -73,6 +73,12 @@
+ # BootMode constant
+ _NON_PERSISTENT_BOOT_MODE = 'OneTime'
+ 
++# Clear job id's constant
++_CLEAR_JOB_IDS = 'JID_CLEARALL_FORCE'
++
++# Clean steps constant
++_CLEAR_JOBS_CLEAN_STEPS = ['clear_job_queue', 'known_good_state']
++
+ 
+ def _get_boot_device(node, drac_boot_devices=None):
+     client = drac_common.get_drac_client(node)
+@@ -180,10 +186,25 @@
+     :raises: DracOperationError on an error from python-dracclient.
+     """
+ 
+-    drac_job.validate_job_queue(node)
+-
+     client = drac_common.get_drac_client(node)
+ 
++    # If pending BIOS job or pending non-BIOS job found in job queue,
++    # we need to clear that jobs before executing clear_job_queue or
++    # known_good_state clean step of management interface.
++    # Otherwise, pending BIOS config job can cause creating new config jobs
++    # to fail and pending non-BIOS job can execute on reboot the node.
++    validate_job_queue = True
++    if node.driver_internal_info.get("clean_steps"):
++        if node.driver_internal_info.get("clean_steps")[0].get(
++                'step') in _CLEAR_JOBS_CLEAN_STEPS:
++            unfinished_jobs = drac_job.list_unfinished_jobs(node)
++            if unfinished_jobs:
++                validate_job_queue = False
++                client.delete_jobs(job_ids=[job.id for job in unfinished_jobs])
++
++    if validate_job_queue:
++        drac_job.validate_job_queue(node)
++
+     try:
+         drac_boot_devices = client.list_boot_devices()
+ 
+@@ -357,3 +378,52 @@
+                   sensor type, which can be processed by Ceilometer.
+         """
+         raise NotImplementedError()
++
++    @METRICS.timer('DracManagement.reset_idrac')
++    @base.clean_step(priority=0)
++    def reset_idrac(self, task):
++        """Reset the iDRAC.
++
++        :param task: a TaskManager instance containing the node to act on.
++        :returns: None if it is completed.
++        :raises: DracOperationError on an error from python-dracclient.
++        """
++        node = task.node
++
++        client = drac_common.get_drac_client(node)
++        client.reset_idrac(force=True, wait=True)
++
++    @METRICS.timer('DracManagement.known_good_state')
++    @base.clean_step(priority=0)
++    def known_good_state(self, task):
++        """Reset the iDRAC, Clear the job queue.
++
++        :param task: a TaskManager instance containing the node to act on.
++        :returns: None if it is completed.
++        :raises: DracOperationError on an error from python-dracclient.
++        """
++        node = task.node
++
++        client = drac_common.get_drac_client(node)
++        client.reset_idrac(force=True, wait=True)
++        client.delete_jobs(job_ids=[_CLEAR_JOB_IDS])
++
++    @METRICS.timer('DracManagement.clear_job_queue')
++    @base.clean_step(priority=0)
++    def clear_job_queue(self, task):
++        """Clear the job queue.
++
++        :param task: a TaskManager instance containing the node to act on.
++        :returns: None if it is completed.
++        :raises: DracOperationError on an error from python-dracclient.
++        """
++        try:
++            node = task.node
++
++            client = drac_common.get_drac_client(node)
++            client.delete_jobs(job_ids=[_CLEAR_JOB_IDS])
++        except drac_exceptions.BaseClientException as exc:
++            LOG.error('DRAC driver failed to clear the job queue for node '
++                      '%(node_uuid)s. Reason: %(error)s.',
++                      {'node_uuid': node.uuid, 'error': exc})
++            raise exception.DracOperationError(error=exc)


### PR DESCRIPTION
Hi Chris,

I have added monkey patch for reset_idrac, known_good_state and clear_job_queue clean steps of management interface.

Please find link of patches below:
1)DRAC: Adding reset_idrac and known_good_state cleaning steps
https://review.opendev.org/#/c/658271/

2)DRAC : clear_job_queue clean step to fix pending bios config jobs
https://review.opendev.org/#/c/674021/

3)DRAC: Fix a bug for clear_job_queue clean step with non-BIOS pending job
https://review.opendev.org/#/c/683161/

Thanks.