### PR TITLE
Drives conversion jbod to raid prior create_configuration

### DIFF
--- a/src/pilot/drac.patch
+++ b/src/pilot/drac.patch
@@ -6,10 +6,10 @@
                        'checks to determine whether the asynchronous RAID '
 -                      'configuration was successfully finished or not.'))
 +                      'configuration was successfully finished or not.')),
-+    cfg.IntOpt('wait_job_status_timeout',
++    cfg.IntOpt('config_job_max_retries',
 +               default=240,
 +               min=1,
-+               help=_('Maximum amount of retries to wait for '
++               help=_('Maximum number of retries for '
 +                      'the configuration job to complete '
 +                      'successfully. '))
  ]

--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -301,6 +301,23 @@ sudo rm -f /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/raid.pyc
 sudo rm -f /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/raid.pyo
 echo "## Done."
 
+# This hacks in a patch to make conductor wait while completion of configuration job
+echo
+echo "## Patching Ironic iDRAC driver job.py..."
+apply_patch "sudo patch -b -s /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/job.py ${HOME}/pilot/ironic_job.patch"
+sudo rm -f /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/job.pyc
+sudo rm -f /usr/lib/python2.7/site-packages/ironic/drivers/modules/drac/job.pyo
+echo "## Done."
+
+# This hacks in a patch to define maximum number of retries for the conductor
+# to wait during any configuration job completion.
+echo
+echo "## Patching Ironic iDRAC driver drac.py..."
+apply_patch "sudo patch -b -s /usr/lib/python2.7/site-packages/ironic/conf/drac.py ${HOME}/pilot/drac.patch"
+sudo rm -f /usr/lib/python2.7/site-packages/ironic/conf/drac.pyc
+sudo rm -f /usr/lib/python2.7/site-packages/ironic/conf/drac.pyo
+echo "## Done."
+
 # This hacks in a patch to add clean steps in management interface.
 echo
 echo "## Patching Ironic iDRAC driver management.py..."

--- a/src/pilot/ironic_job.patch
+++ b/src/pilot/ironic_job.patch
@@ -1,0 +1,33 @@
+19a20
+> import retrying
+22a24
+> from ironic.conf import CONF
+28c30
+< 
+---
+> WAIT_CLOCK = 5
+82a85,108
+> 
+> 
+> @retrying.retry(
+>     retry_on_exception=lambda e: isinstance(e, exception.DracOperationError),
+>     stop_max_attempt_number=CONF.drac.config_job_max_retries,
+>     wait_fixed=WAIT_CLOCK * 1000)
+> def wait_for_job_completion(node,
+>                             retries=CONF.drac.config_job_max_retries):
+>     """Wait for job to complete
+> 
+>     It will wait for the job to complete for 20 minutes and raises timeout
+>     if job never complete within given interval of time.
+>     :param node: an ironic node object.
+>     :param retries: no of retries to make conductor wait.
+>     :raises: DracOperationError on exception raised from python-dracclient
+>     or a timeout while waiting for job completion.
+>     """
+>     if not list_unfinished_jobs(node):
+>         return
+>     err_msg = _(
+>         'There are unfinished jobs in the job '
+>         'queue on node %(node_uuid)s ') % {'node_uuid': node.uuid}
+>     LOG.warning(err_msg)
+>     raise exception.DracOperationError(error=err_msg)

--- a/src/pilot/ironic_job.patch
+++ b/src/pilot/ironic_job.patch
@@ -1,33 +1,49 @@
-19a20
-> import retrying
-22a24
-> from ironic.conf import CONF
-28c30
-< 
----
-> WAIT_CLOCK = 5
-82a85,108
-> 
-> 
-> @retrying.retry(
->     retry_on_exception=lambda e: isinstance(e, exception.DracOperationError),
->     stop_max_attempt_number=CONF.drac.config_job_max_retries,
->     wait_fixed=WAIT_CLOCK * 1000)
-> def wait_for_job_completion(node,
->                             retries=CONF.drac.config_job_max_retries):
->     """Wait for job to complete
-> 
->     It will wait for the job to complete for 20 minutes and raises timeout
->     if job never complete within given interval of time.
->     :param node: an ironic node object.
->     :param retries: no of retries to make conductor wait.
->     :raises: DracOperationError on exception raised from python-dracclient
->     or a timeout while waiting for job completion.
->     """
->     if not list_unfinished_jobs(node):
->         return
->     err_msg = _(
->         'There are unfinished jobs in the job '
->         'queue on node %(node_uuid)s ') % {'node_uuid': node.uuid}
->     LOG.warning(err_msg)
->     raise exception.DracOperationError(error=err_msg)
+--- job_original.py	2019-10-17 00:56:32.872340513 -0500
++++ job.py	2019-10-17 00:58:34.294803657 -0500
+@@ -17,15 +17,17 @@
+ 
+ from oslo_log import log as logging
+ from oslo_utils import importutils
++import retrying
+ 
+ from ironic.common import exception
+ from ironic.common.i18n import _
++from ironic.conf import CONF
+ from ironic.drivers.modules.drac import common as drac_common
+ 
+ drac_exceptions = importutils.try_import('dracclient.exceptions')
+ 
+ LOG = logging.getLogger(__name__)
+-
++WAIT_CLOCK = 5
+ 
+ def validate_job_queue(node):
+     """Validates the job queue on the node.
+@@ -80,3 +82,27 @@
+                   {'node_uuid': node.uuid,
+                    'error': exc})
+         raise exception.DracOperationError(error=exc)
++
++
++@retrying.retry(
++    retry_on_exception=lambda e: isinstance(e, exception.DracOperationError),
++    stop_max_attempt_number=CONF.drac.config_job_max_retries,
++    wait_fixed=WAIT_CLOCK * 1000)
++def wait_for_job_completion(node,
++                            retries=CONF.drac.config_job_max_retries):
++    """Wait for job to complete
++
++    It will wait for the job to complete for 20 minutes and raises timeout
++    if job never complete within given interval of time.
++    :param node: an ironic node object.
++    :param retries: no of retries to make conductor wait.
++    :raises: DracOperationError on exception raised from python-dracclient
++    or a timeout while waiting for job completion.
++    """
++    if not list_unfinished_jobs(node):
++        return
++    err_msg = _(
++        'There are unfinished jobs in the job '
++        'queue on node %(node_uuid)r ') % {'node_uuid': node.uuid}
++    LOG.warning(err_msg)
++    raise exception.DracOperationError(error=err_msg)

--- a/src/pilot/raid.patch
+++ b/src/pilot/raid.patch
@@ -1,6 +1,14 @@
---- raid_original.py	2019-10-14 11:16:03.397389106 +0000
-+++ raid_new.py	2019-10-14 11:14:59.015102633 +0000
-@@ -34,6 +34,7 @@
+--- raid.py.orig	2019-10-18 09:02:42.125751075 -0400
++++ raid_new.py	2019-10-18 09:14:46.549693437 -0400
+@@ -15,6 +15,7 @@
+ DRAC RAID specific methods
+ """
+ 
++from collections import defaultdict
+ import math
+ 
+ from futurist import periodics
+@@ -34,6 +35,7 @@
  from ironic.drivers.modules.drac import common as drac_common
  from ironic.drivers.modules.drac import job as drac_job
  
@@ -8,7 +16,7 @@
  drac_exceptions = importutils.try_import('dracclient.exceptions')
  
  LOG = logging.getLogger(__name__)
-@@ -134,6 +135,34 @@
+@@ -134,6 +136,34 @@
          raise exception.DracOperationError(error=exc)
  
  
@@ -43,7 +51,7 @@
  def create_virtual_disk(node, raid_controller, physical_disks, raid_level,
                          size_mb, disk_name=None, span_length=None,
                          span_depth=None):
-@@ -202,7 +231,70 @@
+@@ -202,7 +232,108 @@
          raise exception.DracOperationError(error=exc)
  
  
@@ -111,11 +119,49 @@
 +        raise exception.DracOperationError(error=exc)
 +
 +
++
++def change_physical_disk_state(node, mode=None,
++                               controllers_to_physical_disk_ids=None):
++    """Convert disks RAID status
++
++    This method converts the requested physical disks from
++    RAID to JBOD or vice versa.  It does this by only converting the
++    disks that are not already in the correct state.
++
++    :param node: an ironic node object.
++    :param mode: the mode to change the disks either to RAID or JBOD.
++    :param controllers_to_physical_disk_ids: Dictionary of controllers and
++           corresponding disk ids to convert to the requested mode.
++    :return: a dictionary containing:
++             - conversion_results, a dictionary that maps controller ids
++             to the conversion results for that controller.
++             The conversion results are a dict that contains:
++             - The is_commit_required key with the value always set to
++             True indicating that a config job must be created to
++             complete disk conversion.
++             - The is_reboot_required key with a RebootRequired
++             enumerated value indicating whether the server must be
++             rebooted to complete disk conversion.
++    :raises: DRACOperationError on an error from python-dracclient.
++    """
++    try:
++        drac_job.validate_job_queue(node)
++        client = drac_common.get_drac_client(node)
++        return client.change_physical_disk_state(
++            mode, controllers_to_physical_disk_ids)
++    except drac_exceptions.BaseClientException as exc:
++        LOG.error('DRAC driver failed to change physical drives '
++                  'to %(mode)s mode for node %(node_uuid)s. '
++                  'Reason: %(error)s.',
++                  {'mode': mode, 'node_uuid': node.uuid, 'error': exc})
++        raise exception.DracOperationError(error=exc)
++
++
 +def commit_config(node, raid_controller, reboot=False, realtime=False):
      """Apply all pending changes on a RAID controller.
  
      :param node: an ironic node object.
-@@ -215,7 +307,9 @@
+@@ -215,7 +346,9 @@
      client = drac_common.get_drac_client(node)
  
      try:
@@ -126,7 +172,41 @@
      except drac_exceptions.BaseClientException as exc:
          LOG.error('DRAC driver failed to commit pending RAID config for'
                    ' controller %(raid_controller_fqdd)s on node '
-@@ -630,35 +724,98 @@
+@@ -226,6 +359,33 @@
+         raise exception.DracOperationError(error=exc)
+ 
+ 
++def _change_physical_disk_mode(node, mode=None,
++                               controllers_to_physical_disk_ids=None):
++    """Physical drives conversion from RAID to JBOD or vice-versa.
++
++    :param node: an ironic node object.
++    :param mode: the mode to change the disks either to RAID or JBOD.
++    :param controllers_to_physical_disk_ids: Dictionary of controllers and
++           corresponding disk ids to convert to the requested mode.
++    :returns: states.CLEANWAIT if deletion is in progress asynchronously
++              or None if it is completed.
++    """
++    change_disk_state = change_physical_disk_state(
++        node, mode, controllers_to_physical_disk_ids)
++
++    controllers = list()
++    conversion_results = change_disk_state['conversion_results']
++    for controller_id, result in conversion_results.items():
++        controller = {'raid_controller': controller_id,
++                      'is_reboot_required': result['is_reboot_required'],
++                      'is_commit_required': result['is_commit_required']}
++        controllers.append(controller)
++
++    return _commit_to_controllers(
++        node,
++        controllers, substep='completed')
++
++
+ def abandon_config(node, raid_controller):
+     """Deletes all pending changes on a RAID controller.
+ 
+@@ -630,35 +790,98 @@
      return filtered_disks
  
  
@@ -226,37 +306,66 @@
 +    else:
 +        for controller in controllers:
 +            mix_controller = controller['raid_controller']
-+            reboot = True if controller == controllers[-1] else False
++            reboot = (controller == controllers[-1])
 +            job_details = _create_config_job(
 +                node, controller=mix_controller,
 +                reboot=reboot, realtime=False,
 +                raid_config_job_ids=raid_config_job_ids,
 +                raid_config_parameters=raid_config_parameters)
 +
-+    driver_internal_info['raid_config_job_ids'] = job_details[
-+        'raid_config_job_ids']
++    driver_internal_info['raid_config_job_ids'].extend(job_details[
++        'raid_config_job_ids'])
  
 -        driver_internal_info['raid_config_job_ids'].append(job_id)
-+    driver_internal_info['raid_config_parameters'] = job_details[
-+        'raid_config_parameters']
++    driver_internal_info['raid_config_parameters'].extend(job_details[
++        'raid_config_parameters'])
  
      node.driver_internal_info = driver_internal_info
      node.save()
-@@ -735,10 +892,10 @@
+@@ -735,10 +958,39 @@
          logical_disks_to_create = _filter_logical_disks(
              logical_disks, create_root_volume, create_nonroot_volumes)
  
 -        controllers = set()
-+        controllers = list()
++        controllers_to_physical_disk_ids = defaultdict(list)
          for logical_disk in logical_disks_to_create:
 -            controllers.add(logical_disk['controller'])
 -            create_virtual_disk(
++            # Not applicable to JBOD logical disks.
++            if logical_disk['raid_level'] == 'JBOD':
++                continue
++
++            for physical_disk_name in logical_disk['physical_disks']:
++                controllers_to_physical_disk_ids[
++                    logical_disk['controller']].append(
++                    physical_disk_name)
++
++        if logical_disks_to_create:
++            LOG.debug(
++                "Converting physical disks configured to back RAID "
++                "logical disks to RAID mode for node %(node_uuid)s ",
++                {"node_uuid": node.uuid})
++            raid = drac_constants.RaidStatus.raid
++            _change_physical_disk_mode(
++                node, raid, controllers_to_physical_disk_ids)
++
++            LOG.debug("Waiting for physical disk conversion to complete "
++                      "for node %(node_uuid)s. ", {"node_uuid": node.uuid})
++            drac_job.wait_for_job_completion(node)
++
++            LOG.info(
++                "Completed converting physical disks configured to back RAID "
++                "logical disks to RAID mode for node %(node_uuid)s",
++                {'node_uuid': node.uuid})
++
++        controllers = list()
++        for logical_disk in logical_disks_to_create:
 +            controller = dict()
 +            controller_cap = create_virtual_disk(
                  node,
                  raid_controller=logical_disk['controller'],
                  physical_disks=logical_disk['physical_disks'],
-@@ -747,8 +904,15 @@
+@@ -747,8 +999,15 @@
                  disk_name=logical_disk.get('name'),
                  span_length=logical_disk.get('span_length'),
                  span_depth=logical_disk.get('span_depth'))
@@ -273,7 +382,7 @@
  
      @METRICS.timer('DracRAID.delete_configuration')
      @base.clean_step(priority=0)
-@@ -762,12 +926,21 @@
+@@ -762,12 +1021,21 @@
          """
          node = task.node
  
@@ -300,7 +409,7 @@
  
      @METRICS.timer('DracRAID.get_logical_disks')
      def get_logical_disks(self, task):
-@@ -840,9 +1013,9 @@
+@@ -840,9 +1108,9 @@
          for config_job_id in raid_config_job_ids:
              config_job = drac_job.get_job(node, job_id=config_job_id)
  
@@ -312,7 +421,7 @@
                  finished_job_ids.append(config_job_id)
                  self._set_raid_config_job_failure(node)
  
-@@ -852,13 +1025,60 @@
+@@ -852,13 +1120,60 @@
          task.upgrade_lock()
          self._delete_cached_config_job_id(node, finished_job_ids)
  


### PR DESCRIPTION
Hi Chris,

I have added monkey patch for drives conversion from jbod to raid-
 [679093](https://review.opendev.org/#/c/679093/)

I have tested ironic_job.patch with full deployment  and its working. but i have tested raid.patch manually by running patch command and it works fine.

Please have a look.

Thanks