### PR TITLE
KickStart updates for SAH

### DIFF
--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -371,7 +371,7 @@ domain=domain.net
 overcloud_nodes_pwd=
 
 # , separated list of ntp servers
-ntp_servers=0.centos.pool.ntp.org,1.centos.pool.ntp.org,2.centos.pool.ntp.org,3.centos.pool.ntp.org
+ntp_servers=0.centos.pool.ntp.org
 time_zone=America/Chicago
 
 # Use static ip adresses for the overcloud nodes if set to true (ips need to be defined in the .properties)

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -370,7 +370,7 @@ domain=domain.net
 overcloud_nodes_pwd=
 
 # , separated list of ntp servers
-ntp_servers=0.centos.pool.ntp.org,1.centos.pool.ntp.org,2.centos.pool.ntp.org,3.centos.pool.ntp.org
+ntp_servers=0.centos.pool.ntp.org
 time_zone=America/Chicago
 
 # Use static ip adresses for the overcloud nodes if set to true (ips need to be defined in the .properties)

--- a/src/mgmt/osp-sah.ks
+++ b/src/mgmt/osp-sah.ks
@@ -47,7 +47,6 @@ auth --enableshadow --passalgo=sha512
 
 skipx
 text
-firewall --disable
 firstboot --disable
 eula --agreed
 
@@ -481,7 +480,6 @@ sed -i -e "s/^SELINUX=.*/SELINUX=permissive/" /etc/selinux/config
 # Configure the system files
 echo "POST: Configure the system files..."
 echo "HOSTNAME=${HostName}" >> /etc/sysconfig/network
-echo "GATEWAY=${Gateway}" >> /etc/sysconfig/network
 
 read -a htmp <<< ${public_bond}
 echo "${htmp[2]}  ${HostName}" >> /etc/hosts
@@ -564,15 +562,12 @@ mkdir -p /store/data/iso
 echo "POST: Install other rerquired packages, paramiko, ..."
 yum install -y gcc libffi-devel openssl-devel ipmitool tmux git
 
-echo "POST: get and install pip"
-curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
-python get-pip.py
 # temporary workaround for CES-7248 
 echo "POST: upgrade setuptools"
-pip install --upgrade setuptools
-pip install paramiko
-pip install selenium
-pip install cryptography
+pip3 install --upgrade setuptools
+pip3 install paramiko
+pip3 install selenium
+pip3 install cryptography
 echo "POST: Done installing extra packages"
 
 echo 'export PYTHONPATH=/usr/bin/python:/lib/python3.6:/lib/python3.6/site-packages:/root/JetPack/src/deploy/' >> /root/.bashrc


### PR DESCRIPTION
KickStart has been updated and following issues have been resolved:
1- Default GW in /etc/sysconfig/network has been removed as it doesn't work and caused conflict with GW in ifcfg files, GW is defined in ifcfg files instead.
2- Excess ntp servers have been removed from example ini files and only one pool is left as example, another pool exists already in chrony.conf by default
3- Removed "firewall --disable"  as it is not required to disable it and current configurations work good regardless of it being enabled or disabled.
4- pip commands have been updated to pip3 for python3.6 compatibility