### PR TITLE
[CES-10891] Python 3 changes to support RHOSP 15

### DIFF
--- a/src/deploy/auto_common/Scp.py
+++ b/src/deploy/auto_common/Scp.py
@@ -21,7 +21,7 @@ except ImportError:
 
 
 # noinspection PyClassHasNoInit
-class Scp():
+class Scp:
 
     @staticmethod
     def get_file(adress, user, passw, localfile, remotefile):

--- a/src/deploy/auto_common/file_utils.py
+++ b/src/deploy/auto_common/file_utils.py
@@ -19,7 +19,7 @@ import codecs
 
 
 # noinspection PyClassHasNoInit
-class FileHelper():
+class FileHelper:
     @staticmethod
     def replace_expression(fileref, search_exp, replace_exp):
         fh = open(fileref, 'rU')

--- a/src/deploy/auto_common/ipmi.py
+++ b/src/deploy/auto_common/ipmi.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 
 
-class Ipmi():
+class Ipmi:
     """
     this assumes CygWin is installed along with ipmi
     (if used on windows)

--- a/src/deploy/auto_common/ssh.py
+++ b/src/deploy/auto_common/ssh.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 
 # noinspection PyClassHasNoInit
-class Ssh():
+class Ssh:
     @staticmethod
     def execute_command_readlines(address, usr, pwd, command):
         try:

--- a/src/deploy/auto_common/ui_helper.py
+++ b/src/deploy/auto_common/ui_helper.py
@@ -19,7 +19,7 @@ import time
 
 
 # noinspection PyClassHasNoInit,PyUnresolvedReferences,PyProtectedMember
-class UIHelper():
+class UIHelper:
     @staticmethod
     def verify_new_window_opened(page_title):
         """

--- a/src/deploy/auto_common/ui_manager.py
+++ b/src/deploy/auto_common/ui_manager.py
@@ -27,7 +27,7 @@ SEL = None
 
 
 # noinspection PyClassHasNoInit
-class UIManager():
+class UIManager:
 
     @staticmethod
     def driver():
@@ -37,7 +37,7 @@ class UIManager():
 
 
 # noinspection PyProtectedMember
-class Widget():
+class Widget:
 
     def __init__(self, locator):
         self.locator = locator

--- a/src/deploy/osp_deployer/checkpoints.py
+++ b/src/deploy/osp_deployer/checkpoints.py
@@ -21,7 +21,7 @@ import logging
 logger = logging.getLogger("osp_deployer")
 
 
-class Checkpoints():
+class Checkpoints:
     def __init__(self):
         self.settings = Settings.settings
         self.ping_success = "packets transmitted, 1 received"

--- a/src/deploy/osp_deployer/deployer.py
+++ b/src/deploy/osp_deployer/deployer.py
@@ -273,8 +273,8 @@ def deploy():
         logger.error(traceback.format_exc())
         e = sys.exc_info()[0]
         logger.error(e)
-        print e
-        print traceback.format_exc()
+        print(e)
+        print(traceback.format_exc())
         ret_code = 1
     logger.info("log : /auto_results/ ")
     sys.exit(ret_code)

--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -1299,7 +1299,7 @@ class Director(InfraHost):
         cmds = []
         remote_file = os.path.join(self.nic_configs_dir,
                                    self.settings.nic_env_file)
-        for setting_name, setting_value in ini_nics_settings.iteritems():
+        for setting_name, setting_value in ini_nics_settings.items():
             # The following is executing a sed command of the following format:
             # sed -i -r 's/(^\s*StorageBond0Interface1:\s*).*/\1p1p2/'
             cmds.append('sed -i -r \'s/(^\s*' + setting_name +    # noqa: W605
@@ -1924,7 +1924,7 @@ class Director(InfraHost):
         sriov_conf = {}
 
         # Get and sort the SR-IOV interfaces that user provided
-        for int_name, int_value in ini_nics_settings.iteritems():
+        for int_name, int_value in ini_nics_settings.items():
             if int_name.find('ComputeSriov') != -1:
                 sriov_conf.update({int_name: int_value})
         sriov_interfaces = [x[1] for x in sorted(sriov_conf.items())]

--- a/src/deploy/osp_deployer/infra_host.py
+++ b/src/deploy/osp_deployer/infra_host.py
@@ -17,7 +17,7 @@
 from auto_common import Ssh, Scp
 
 
-class InfraHost():
+class InfraHost:
 
     def __init__(self):
 

--- a/src/deploy/osp_deployer/node_conf.py
+++ b/src/deploy/osp_deployer/node_conf.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 
-class NodeConf():
+class NodeConf:
 
     def __init__(self, json):
         self.is_sah = False

--- a/src/deploy/osp_deployer/profile.py
+++ b/src/deploy/osp_deployer/profile.py
@@ -20,13 +20,13 @@ import os
 import json
 import inspect
 import logging
-from ConfigParser import ConfigParser
+from configparser import ConfigParser
 from osp_deployer.settings.config import Settings
 
 logger = logging.getLogger("osp_deployer")
 
 
-class Profile():
+class Profile:
     def __init__(self):
 
         self.settings = Settings.settings
@@ -54,8 +54,8 @@ class Profile():
                             "/" + profile_definition['sample_ini'])
         Err = ''
         for items in profile_definition['associated_settings']:
-            for stanza, value in items.iteritems():
-                for set, vals in value.iteritems():
+            for stanza, value in items.items():
+                for set, vals in value.items():
                     allowed_settings = []
                     validated = False
                     try:

--- a/src/deploy/osp_deployer/settings/config.py
+++ b/src/deploy/osp_deployer/settings/config.py
@@ -20,13 +20,13 @@ import re
 import inspect
 import json
 import subprocess
-import ConfigParser
+import configparser
 from osp_deployer.node_conf import NodeConf
 
 logger = logging.getLogger("osp_deployer")
 
 
-class Settings():
+class Settings:
     CEPH_OSD_CONFIG_FILE = 'pilot/templates/ceph-osd-config.yaml'
     TEMPEST_DEFAULT_WORKSPACE_NAME = 'mytempest'
 
@@ -40,13 +40,13 @@ class Settings():
         f_name = "/sample_xsp_profile.ini"
         sample_ini = os.path.dirname(inspect.getfile(Settings)) + f_name
 
-        conf = ConfigParser.ConfigParser()
+        conf = configparser.ConfigParser()
         # The following line makes the parser return case sensitive keys
         conf.optionxform = str
         conf.read(sample_ini)
 
         your_ini = settings_file
-        yourConf = ConfigParser.ConfigParser()
+        yourConf = configparser.ConfigParser()
         # The following line makes the parser return case sensitive keys
         yourConf.optionxform = str
         yourConf.read(your_ini)
@@ -705,7 +705,7 @@ class Settings():
                 dictr[option] = self.conf.get(section, option)
                 if dictr[option] == -1:
                     logger.debug("skip: %s" % option)
-            except ConfigParser.NoSectionError:
+            except configparser.NoSectionError:
                 logger.debug("exception on %s!" % option)
                 dictr[option] = None
         return dictr

--- a/src/deploy/osp_deployer/settings_sanity.py
+++ b/src/deploy/osp_deployer/settings_sanity.py
@@ -25,7 +25,7 @@ import yaml
 logger = logging.getLogger("osp_deployer")
 
 
-class DeployerSanity():
+class DeployerSanity:
     def __init__(self):
         self.settings = Settings.settings
 
@@ -339,14 +339,14 @@ class DeployerSanity():
                 try:
                     os_volume_size_gb = int(node.os_volume_size_gb)
                 except ValueError:
-                    raise AssertionError("os_volume_size_gb of \"{}\" on node "
+                    raise AssertionError("os_volume_size_gb of \"{}\" on node " +
                                          "{} is not an integer".format(
                                              node.os_volume_size_gb,
                                              node.idrac_ip))
 
                 if os_volume_size_gb <= 0:
-                    raise AssertionError("os_volume_size_gb of \"{}\" on node "
-                                         "\"{}\" on node {} is not a positive "
+                    raise AssertionError("os_volume_size_gb of \"{}\" on node " +
+                                         "\"{}\" on node {} is not a positive " +
                                          "integer".format(
                                              node.os_volume_size_gb,
                                              node.idrac_ip))

--- a/src/deploy/setup/setup_usb_idrac.py
+++ b/src/deploy/setup/setup_usb_idrac.py
@@ -119,8 +119,8 @@ def setup():
         logger.error(traceback.format_exc())
         e = sys.exc_info()[0]
         logger.error(e)
-        print e
-        print traceback.format_exc()
+        print(e)
+        print(traceback.format_exc())
 
 
 if __name__ == "__main__":

--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -507,7 +507,7 @@ def find_physical_disks_for_storage_os(physical_disks):
         LOG.critical(
             "Could not find physical disks for operating system logical disk")
 
-    return (os_logical_disk_size_gb, os_physical_disk_names)
+    return os_logical_disk_size_gb, os_physical_disk_names
 
 
 def cardinality_of_smallest_spinning_disk_size_is_two(physical_disks):
@@ -523,7 +523,7 @@ def cardinality_of_smallest_spinning_disk_size_is_two(physical_disks):
 
     # Handle the case where we have no spinning disks
     if not ordered_disks_by_size:
-        return (0, None)
+        return 0, None
 
     # Obtain the bin for the smallest size.
     smallest_disks_bin = ordered_disks_by_size[0]
@@ -535,9 +535,9 @@ def cardinality_of_smallest_spinning_disk_size_is_two(physical_disks):
     if cardinality_of_smallest_disks == 2:
         sorted_smallest_disk_ids = sorted((d.id for d in smallest_disks),
                                           key=physical_disk_id_to_key)
-        return (smallest_disk_size, sorted_smallest_disk_ids)
+        return smallest_disk_size, sorted_smallest_disk_ids
     else:
-        return (0, None)
+        return 0, None
 
 
 def last_two_disks_by_location(physical_disks):
@@ -550,7 +550,7 @@ def last_two_disks_by_location(physical_disks):
     # The two disks (2) must be of the same media type, hard disk drive
     # (HDD) spinner or solid state drive (SSD).
     if last_two_disks[0].media_type != last_two_disks[1].media_type:
-        return (0, None)
+        return 0, None
 
     # Determine the smallest size of the two (2) disks, in gigabytes.
 
@@ -584,7 +584,7 @@ def last_two_disks_by_location(physical_disks):
 
     last_two_disk_ids = [d.id for d in last_two_disks]
 
-    return (logical_disk_size_gb, last_two_disk_ids)
+    return logical_disk_size_gb, last_two_disk_ids
 
 
 def bin_physical_disks_by_size_gb(physical_disks, media_type_filter=None):
@@ -709,9 +709,9 @@ def physical_disk_to_key(physical_disk):
 
 def configure_raid(ironic_client, node_uuid, role, os_volume_size_gb,
                    drac_client):
-    '''TODO: Add some selective exception handling so we can determine
+    """TODO: Add some selective exception handling so we can determine
     when RAID configuration failed and return False. Further testing
-    should uncover interesting error conditions.'''
+    should uncover interesting error conditions."""
 
     if get_raid_controller_id(drac_client) is None:
         LOG.warning("No RAID controller is present.  Skipping RAID "
@@ -733,9 +733,9 @@ def configure_raid(ironic_client, node_uuid, role, os_volume_size_gb,
     # configuration, and then to create it. The workarounds are inserted
     # in-between.
 
-    '''TODO: After those upstream bugs have been resolved, perform both
+    """TODO: After those upstream bugs have been resolved, perform both
     clean steps, delete_configurtion() and create_configuration(),
-    during one (1) manual cleaning.'''
+    during one (1) manual cleaning."""
 
     LOG.info("Deleting the existing RAID configuration")
     clean_steps = [{'interface': 'raid', 'step': 'delete_configuration'}]

--- a/src/pilot/command_helper.py
+++ b/src/pilot/command_helper.py
@@ -21,7 +21,7 @@ import subprocess
 logger = logging.getLogger(__name__)
 
 
-class Scp():
+class Scp:
 
     @staticmethod
     def get_file(address, localfile, remotefile,
@@ -46,7 +46,7 @@ class Scp():
         client.close()
 
 
-class Ssh():
+class Ssh:
 
     @staticmethod
     def get_client(address, user=None, password=None, pkey=None):
@@ -76,7 +76,7 @@ class Ssh():
         return exit_code, stdout, stderr
 
 
-class Exec():
+class Exec:
 
     @staticmethod
     def execute_command(cmd):

--- a/src/pilot/config_dashboard.py
+++ b/src/pilot/config_dashboard.py
@@ -229,7 +229,7 @@ def get_ceph_nodes(username):
             # as it is not ever used to coonfigure the dashboard
             node.fqdn = node.fqdn + ".mydomain"
             # if (node.fqdn.find(".")):
-            if ('.' in node.fqdn):
+            if '.' in node.fqdn:
                 node.fqdn, domain_name = node.fqdn.split('.', 1)
             else:
                 node.fqdn = node.fqdn

--- a/src/pilot/config_idrac.py
+++ b/src/pilot/config_idrac.py
@@ -224,7 +224,7 @@ def configure_bios_nics_boot_settings(drac_client, ip_service_tag, pxe_nic_id):
                     result = set_nic_legacy_boot_protocol_none(
                         nic_id, drac_client)
             except exceptions.InvalidParameterValue:
-                LOG.warn("Unable to check the legacy boot protocol of NIC {} "
+                LOG.warning("Unable to check the legacy boot protocol of NIC {} "
                          "on {}, and so cannot set it to None".format(
                              nic_id, ip_service_tag))
 
@@ -445,7 +445,7 @@ def config_idrac_settings(drac_client, ip_service_tag, password, node):
     }
 
     if password:
-        LOG.warn("Updating the password on {}".format(ip_service_tag))
+        LOG.warning("Updating the password on {}".format(ip_service_tag))
         idrac_settings["Users.2#Password"] = password
 
     # Set the iDRAC card attributes
@@ -569,10 +569,10 @@ def config_idrac(instack_lock,
                  "possible.".format(ip_service_tag, ironic_driver))
 
         if pxe_nic:
-            LOG.warn("Ignoring specified PXE NIC ({})".format(pxe_nic))
+            LOG.warning("Ignoring specified PXE NIC ({})".format(pxe_nic))
 
         if password:
-            LOG.warn("Ignoring specified password")
+            LOG.warning("Ignoring specified password")
 
         return
 
@@ -677,7 +677,7 @@ def config_idrac(instack_lock,
                 drac_client = new_drac_client
             else:
                 success = False
-                LOG.warn("Failed to change the password on {}".format(
+                LOG.warning("Failed to change the password on {}".format(
                     ip_service_tag))
 
         all_jobs_succeeded = wait_for_jobs_to_complete(

--- a/src/pilot/control_overcloud.py
+++ b/src/pilot/control_overcloud.py
@@ -47,7 +47,8 @@ def main():
 
         cmd = "ipmitool -H {} -I lanplus -U {} -P '{}' chassis power {}". \
             format(ip, username, password, args.power)
-        print cmd
+        print(cmd)
+
         os.system(cmd)
 
 

--- a/src/pilot/deploy-overcloud.py
+++ b/src/pilot/deploy-overcloud.py
@@ -140,12 +140,12 @@ def create_flavors():
 
     for flavor in flavors:
         if flavor["id"] not in existing_flavor_ids:
-            print '    Creating ' + flavor["name"]
+            print('    Creating ' + flavor["name"])
             n_client.flavors.create(flavor["name"], flavor["memory"],
                                     flavor["cpus"], flavor["disk"],
                                     flavorid=flavor["id"])
         else:
-            print '    Flavor ' + flavor["name"] + " already exists"
+            print('    Flavor ' + flavor["name"] + " already exists")
 
 
 def create_volume_types():
@@ -597,7 +597,7 @@ def main():
                   'w') as f:
             f.write(cmd.replace(' -', ' \\\n -'))
             f.write('\n')
-        print cmd
+        print(cmd)
         start = time.time()
         status = run_deploy_command(cmd)
         end = time.time()
@@ -618,7 +618,7 @@ def main():
         if horizon_url:
             logger.info('\nHorizon Dashboard URL: {}\n'.format(horizon_url))
     except Exception as err:
-        print >> sys.stderr, err
+        print(sys.stderr, err)
         sys.exit(1)
 
 

--- a/src/pilot/discover_nodes/discover_nodes.py
+++ b/src/pilot/discover_nodes/discover_nodes.py
@@ -19,7 +19,7 @@ from __future__ import print_function
 
 import argparse
 from collections import namedtuple
-from exceptions import ValueError
+from builtins import ValueError
 import json
 import logging
 import os.path

--- a/src/pilot/enable-repos.py
+++ b/src/pilot/enable-repos.py
@@ -32,7 +32,7 @@ repos = [
 
 
 def execute(cmd):
-    print cmd
+    print(cmd)
     return_code = os.system(cmd)
     if return_code != 0:
         sys.exit(return_code)

--- a/src/pilot/identify_nodes.py
+++ b/src/pilot/identify_nodes.py
@@ -56,9 +56,9 @@ def main():
         "+-----------------+---------------------------+-----------------+"
     )
     nodeinfo = "| {:<15} | {:<25} | {:<15} |"
-    print banner
-    print nodeinfo.format('iDRAC Addr', 'Node Name', 'Provision Addr')
-    print banner
+    print(banner)
+    print(nodeinfo.format('iDRAC Addr', 'Node Name', 'Provision Addr')
+    print(banner)
     # Display the list ordered by the iDRAC address
     for n in sorted(nodes, key=lambda x: CredentialHelper.get_drac_ip(x)):
         idrac_addr = CredentialHelper.get_drac_ip(n)
@@ -74,8 +74,8 @@ def main():
             if nova_ips and 'ctlplane' in nova_ips:
                 prov_addr = nova_ips['ctlplane'][0]['addr']
 
-        print nodeinfo.format(idrac_addr, node_name, prov_addr)
-    print banner
+        print(nodeinfo.format(idrac_addr, node_name, prov_addr))
+    print(banner)
 
 
 if __name__ == "__main__":

--- a/src/pilot/logging_helper.py
+++ b/src/pilot/logging_helper.py
@@ -17,7 +17,7 @@
 import logging
 
 
-class LoggingHelper():
+class LoggingHelper:
 
     @staticmethod
     def add_argument(parser, default="INFO"):

--- a/src/pilot/network-validation/validate_networks.py
+++ b/src/pilot/network-validation/validate_networks.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import ConfigParser
 import sys
 import argparse
 import json
@@ -316,7 +315,7 @@ class NetworkValidation(object):
                                             destination_ip,
                                             match.group(1)))
                         else:
-                            logger.warn("      FAILED {0: <20} - {1: <15} "
+                            logger.warning("      FAILED {0: <20} - {1: <15} "
                                         "({2}) network {2}!".format(
                                             destination_node.name,
                                             destination_ip,

--- a/src/pilot/nfv_parameters.py
+++ b/src/pilot/nfv_parameters.py
@@ -81,7 +81,7 @@ class NfvParameters(object):
             if not socket.ht_enabled:
                 raise Exception("Hyperthreading is not enabled in "
                                 + str(node))
-        print "Hyperthreading enabled on %s" % node
+        print("Hyperthreading enabled on %s" % node)
         return True
 
     def get_nodes_uuids(self, nodetype):

--- a/src/pilot/probe_idrac/probe_idrac/probe_idrac.py
+++ b/src/pilot/probe_idrac/probe_idrac/probe_idrac.py
@@ -82,7 +82,7 @@ def main():
     # Probe each iDRAC specified on the command line.
     for i in args.idrac:
         # Identify the iDRAC.
-        print i + ':'
+        print(i + ':')
 
         # Create client for talking to the iDRAC over the WSMan protocol.
         client = dracclient.wsman.Client(i, args.username, args.password)
@@ -91,7 +91,7 @@ def main():
         for d in dcims:
             response = client.enumerate(
                 'http://schemas.dell.com/wbem/wscim/1/cim-schema/2/' + d)
-            print lxml.etree.tostring(response, pretty_print=True)
+            print(lxml.etree.tostring(response, pretty_print=True))
 
 if __name__ == "__main__":
     main()

--- a/src/pilot/register_overcloud.py
+++ b/src/pilot/register_overcloud.py
@@ -253,7 +253,7 @@ class RegisterOvercloud:
                self.proxy_args]
         return_code, stdout = self._execute_cmd(cmd)
         if return_code == 0:
-            self.logger.warn(role + " " + node_ip +
+            self.logger.warning(role + " " + node_ip +
                              " is already registered.  "
                              "Using existing registration")
         else:
@@ -306,7 +306,7 @@ class RegisterOvercloud:
             self.logger.debug("Removed subscriptions from {} "
                               "{} successfully".format(role, node_ip))
         else:
-            self.logger.warn("Unable to remove subscriptions from " + role +
+            self.logger.warning("Unable to remove subscriptions from " + role +
                              " " + node_ip + ": " + stdout)
 
         cmd = ["ssh",
@@ -320,7 +320,7 @@ class RegisterOvercloud:
             self.logger.debug("Unregistered {} {} successfully".format(
                 role, node_ip))
         else:
-            self.logger.warn("Failed to unregister " + role + " " + node_ip +
+            self.logger.warning(("Failed to unregister " + role + " " + node_ip +
                              ": " + stdout)
 
     def _get_consumed_pool_ids(self, node_ip):
@@ -360,7 +360,7 @@ class RegisterOvercloud:
         for pool_id in pool_ids:
             # Check to see if this node is already attached to this pool ID
             if pool_id in consumed_pool_ids:
-                self.logger.warn(role + " " + node_ip +
+                self.logger.warning((role + " " + node_ip +
                                  " is already attached to pool " + pool_id +
                                  ".  Skipping attach")
             else:

--- a/src/pilot/update_ssh_config.py
+++ b/src/pilot/update_ssh_config.py
@@ -106,7 +106,7 @@ def update_known_hosts(host_addrs):
     if os.path.isfile(known_hosts):
         os.rename(known_hosts, known_hosts + '.old')
     os.rename(known_hosts_new, known_hosts)
-    os.chmod(known_hosts, 0600)
+    os.chmod(known_hosts, 0o600)
 
 
 def update_etc_hosts(overcloud):
@@ -138,7 +138,7 @@ def update_etc_hosts(overcloud):
         new_file.write('{}\n'.format(overcloud[node]))
 
     new_file.close()
-    os.chmod(new_hosts, 0644)
+    os.chmod(new_hosts, 0o644)
     os.system('sudo mv {} {}'.format(new_hosts, etc_hosts))
     os.system('sudo chown root:root {}'.format(etc_hosts))
 
@@ -164,7 +164,7 @@ def main():
             f.write("Host {} {}\n".format(node, full_name))
             f.write("  Hostname {}\n".format(addr))
             f.write("  User heat-admin\n\n")
-    os.chmod(ssh_config, 0600)
+    os.chmod(ssh_config, 0o600)
 
     update_known_hosts(overcloud.values())
     update_etc_hosts(overcloud_nodes)

--- a/src/tempest/tempest/cmd/db/mysql/mysql_db.py
+++ b/src/tempest/tempest/cmd/db/mysql/mysql_db.py
@@ -21,9 +21,9 @@ import MySQLdb
 
 
 class MySqlDb(db_base.DbBase):
-    '''
+    """
     classdocs
-    '''
+    """
     def __get_connection__(self):
         return MySQLdb.connect(self.host, self.user,
                                self.passwd, self.db_name)

--- a/src/tempest/tempest/cmd/db_cleanup.py
+++ b/src/tempest/tempest/cmd/db_cleanup.py
@@ -31,7 +31,7 @@ explicitly specify what cleaners are executed. By default only
 reset_quotas.py is in the list of subclasses that will execute.
 """
 import argparse
-import ConfigParser
+import configparser
 import sys
 
 
@@ -52,7 +52,7 @@ class DbCleanup(object):
         # Arbitrary getattr() call required to init config for logging.
         CONF.debug.enable
         self._init_options()
-        self.config = ConfigParser.ConfigParser()
+        self.config = configParser.ConfigParser()
         self.config.read(CLEANUP_DB_CONF)
 
     def run(self):
@@ -68,7 +68,7 @@ class DbCleanup(object):
     def _init_db_conf(self):
         """Create default db config file."""
         LOG.debug("Initialize database configuration")
-        config = ConfigParser.RawConfigParser()
+        config = configparser.RawConfigParser()
 
         secs = ['cinder', 'keystone', 'heat', 'nova', 'swift']
         for sec in secs:


### PR DESCRIPTION
All OpenStack Platform 15 services use Python 3 packages so the syntax of the JetPack code has been update to support Python 3. Major changes include

- dict.iterkeys,, dict.iteritems, and dict.itervalues not available in Python 3. Use dict.keys(), dict.items(), and dict.values() respectively.
- Octal number in needs to be converted to new Python 3 friendly syntax
- ConfigParser renamed to configparser
- print usage has also been updated