### PR TITLE
Pyhton 3 compile error fix

### DIFF
--- a/src/deploy/auto_common/ipmi.py
+++ b/src/deploy/auto_common/ipmi.py
@@ -38,7 +38,7 @@ class Ipmi:
             and fix the missing dependencies etc.
         make
         make install
-        Add c:\cygwin\bin and c:\cygwin\usr\local\bin to your path
+        Add c:\\cygwin\\bin and c:\\cygwin\\usr\\local\\bin to your path
         (or the relevant paths for your setup)
         make sure you can talk to one of your servers :
         in cygwin :

--- a/src/pilot/identify_nodes.py
+++ b/src/pilot/identify_nodes.py
@@ -57,7 +57,7 @@ def main():
     )
     nodeinfo = "| {:<15} | {:<25} | {:<15} |"
     print(banner)
-    print(nodeinfo.format('iDRAC Addr', 'Node Name', 'Provision Addr')
+    print(nodeinfo.format('iDRAC Addr', 'Node Name', 'Provision Addr'))
     print(banner)
     # Display the list ordered by the iDRAC address
     for n in sorted(nodes, key=lambda x: CredentialHelper.get_drac_ip(x)):

--- a/src/pilot/register_overcloud.py
+++ b/src/pilot/register_overcloud.py
@@ -320,7 +320,7 @@ class RegisterOvercloud:
             self.logger.debug("Unregistered {} {} successfully".format(
                 role, node_ip))
         else:
-            self.logger.warning(("Failed to unregister " + role + " " + node_ip +
+            self.logger.warning("Failed to unregister " + role + " " + node_ip +
                              ": " + stdout)
 
     def _get_consumed_pool_ids(self, node_ip):
@@ -360,7 +360,7 @@ class RegisterOvercloud:
         for pool_id in pool_ids:
             # Check to see if this node is already attached to this pool ID
             if pool_id in consumed_pool_ids:
-                self.logger.warning((role + " " + node_ip +
+                self.logger.warning(role + " " + node_ip +
                                  " is already attached to pool " + pool_id +
                                  ".  Skipping attach")
             else:


### PR DESCRIPTION
Python 3 compile was failing because of redundant braces and due to using a single \ for defining paths. 