### PR TITLE
T10 PI format patch

### DIFF
--- a/src/pilot/customize_image.sh
+++ b/src/pilot/customize_image.sh
@@ -144,6 +144,10 @@ if [ ! -z "${satellite_hostname}" ]; then
 else
    run_command "virt-customize -a overcloud-full.qcow2 --run-command \"echo '${director_ip} ${director_short} ${director_long}' >> /etc/hosts\""
 
+   #Patch for configuring T10 PI format drives
+   run_command "virt-customize -a overcloud-full.qcow2  --run-command \"sed -i 's/GRUB_CMDLINE_LINUX=\\\"/GRUB_CMDLINE_LINUX=\\\"mpt3sas.prot_mask=1 /' /etc/default/grub\""
+   run_command "virt-customize -a overcloud-full.qcow2 --run-command \"grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg\""
+
     run_command "virt-customize \
         --memsize 2000 \
         --add overcloud-full.qcow2 \

--- a/src/pilot/templates/first-boot.yaml
+++ b/src/pilot/templates/first-boot.yaml
@@ -178,7 +178,7 @@ resources:
             echo $cmd
             $cmd
             echo
-
+            
           done
           partprobe
           parted -lm


### PR DESCRIPTION
T10 PI format of drives are causing failures deploying solutions. For the fix I added this  'mpt3sas.prot_mask=1' parameter in the 'src/pilot/templates/first-boot.yaml' in the CEPHStorage section so that this parameter is only added to the storage nodes and not applied to all the nodes in the architecture. To verify post-deployment follow these steps:

- ssh in storage node
- goto file /etc/default/grub
- verify if GRUB_CMDLINE_LINUX = 'mpt3sas.prot_mask=1 ...' is set
- also verify /boot/efi/EFI/redhat/grub.cfg