### PR TITLE
T10 PI format patch

### DIFF
--- a/src/pilot/customize_image.sh
+++ b/src/pilot/customize_image.sh
@@ -144,6 +144,12 @@ if [ ! -z "${satellite_hostname}" ]; then
 else
    run_command "virt-customize -a overcloud-full.qcow2 --run-command \"echo '${director_ip} ${director_short} ${director_long}' >> /etc/hosts\""
 
+
+   #Patch for configuring T10 PI format drives
+   run_command "virt-customize -a overcloud-full.qcow2  --run-command \"sed -i 's/GRUB_CMDLINE_LINUX=\\\"/GRUB_CMDLINE_LINUX=\\\"mpt3sas.prot_mask=1 /' /etc/default/grub\""
+   run_command "virt-customize -a overcloud-full.qcow2 --run-command \"grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg\""
+
+
     run_command "virt-customize \
         --memsize 2000 \
         --add overcloud-full.qcow2 \


### PR DESCRIPTION
Patch is implemented using the virt-customize command. To validate the patch

- ssh storage node
- goto /etc/default/grub
- mpt3sas.prot_mask=1 parameter will be present against the value GRUB_CMDLINE_LINUX