### PR TITLE
Deploy OSP15 undercloud

### DIFF
--- a/src/deploy/auto_common/file_utils.py
+++ b/src/deploy/auto_common/file_utils.py
@@ -22,7 +22,7 @@ import codecs
 class FileHelper:
     @staticmethod
     def replace_expression(fileref, search_exp, replace_exp):
-        fh = open(fileref, 'rU')
+        fh = open(fileref, 'r')
         content = fh.readlines()
         fh.close()
         updated = []
@@ -30,7 +30,7 @@ class FileHelper:
             line = re.sub(search_exp, replace_exp, line)
             updated.append(line)
 
-        with codecs.open(fileref, 'wbU', encoding='utf8') as f:
+        with codecs.open(fileref, 'wb', encoding='utf8') as f:
             for line in updated:
                 f.write(line)
         f.close()

--- a/src/deploy/osp_deployer/checkpoints.py
+++ b/src/deploy/osp_deployer/checkpoints.py
@@ -56,7 +56,7 @@ class Checkpoints:
             user,
             password,
             "subscription-manager status")[0]
-        while "Current" not in subscription_status and i < retries:
+        while "Current" not in subscription_status and int(i) < int(retries):
             if "Unknown" in subscription_status:
                 return subscription_status
             time.sleep(60)

--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from settings.config import Settings
+from osp_deployer.settings.config import Settings
 from checkpoints import Checkpoints
 from collections import defaultdict
 from infra_host import InfraHost
@@ -128,11 +128,6 @@ class Director(InfraHost):
             'sed -i "s|local_ip = .*|local_ip = ' +
             self.settings.director_node.provisioning_ip +
             '/24|" pilot/undercloud.conf',
-            'sed -i "s|local_interface = .*|'
-            'local_interface = eth1|" pilot/undercloud.conf',
-            'sed -i "s|masquerade_network = .*|masquerade_network = ' +
-            self.settings.provisioning_network +
-            '|" pilot/undercloud.conf',
             'sed -i "s|dhcp_start = .*|dhcp_start = ' +
             self.settings.provisioning_net_dhcp_start +
             '|" pilot/undercloud.conf',
@@ -147,6 +142,9 @@ class Director(InfraHost):
             '|" pilot/undercloud.conf',
             'sed -i "s|inspection_iprange = .*|inspection_iprange = ' +
             self.settings.discovery_ip_range +
+            '|" pilot/undercloud.conf',
+            'sed -i "s|undercloud_nameservers = .*|undercloud_nameservers = ' +
+            self.settings.name_server +
             '|" pilot/undercloud.conf',
             'sed -i "s|undercloud_ntp_servers = .*|undercloud_ntp_servers = ' +
             self.settings.sah_node.provisioning_ip +

--- a/src/deploy/osp_deployer/sah.py
+++ b/src/deploy/osp_deployer/sah.py
@@ -333,7 +333,6 @@ class Sah(InfraHost):
                 self.settings.domain,
                 "gateway " + self.settings.public_api_gateway,
                 "nameserver " + self.settings.name_server,
-                "ntpserver " + self.settings.sah_node.provisioning_ip,
                 "user " + self.settings.director_install_account_user,
                 "password " + self.settings.director_install_account_pwd,)
         if self.settings.use_satellite is True:

--- a/src/mgmt/deploy-director-vm.sh
+++ b/src/mgmt/deploy-director-vm.sh
@@ -59,6 +59,7 @@ firewall-config
 iptables-services
 yum-utils
 virt-who
+tmux
 %end
 
 %pre --log /tmp/director-pre.log
@@ -66,7 +67,6 @@ EOFKS
 
 
 { 
-ntp=""
 
 while read iface ip mask mtu
 do
@@ -90,7 +90,6 @@ do
     echo "echo Gateway=${ip} >> /tmp/ks_post_include.txt"
     }
 
-  [[ ${iface} == ntpserver ]] && echo "echo NTPServers=${ip} >> /tmp/ks_post_include.txt"
 
   [[ ${iface} == user ]] && echo "echo User=${ip} >> /tmp/ks_post_include.txt"
   [[ ${iface} == password ]] && echo "echo Password=${ip} >> /tmp/ks_post_include.txt"
@@ -166,7 +165,6 @@ EOFPW
     echo "nameserver ${ns}" >> /etc/resolv.conf
   done
 
-  sed -i -e '/^DNS/d' /etc/sysconfig/network-scripts/ifcfg-enp1s0
   sed -i -e '/^DNS/d' -e '/^GATEWAY/d' /etc/sysconfig/network-scripts/ifcfg-enp2s0
   sed -i -e '/^DNS/d' -e '/^GATEWAY/d' /etc/sysconfig/network-scripts/ifcfg-enp3s0
   sed -i -e '/^DNS/d' -e '/^GATEWAY/d' /etc/sysconfig/network-scripts/ifcfg-enp4s0
@@ -275,15 +273,6 @@ EOIP
   sed -i -e "/^net.ipv4.ip_forward/d" /etc/sysctl.conf
   echo "net.ipv4.ip_forward = 1" >> /etc/sysctl.conf
   sysctl -p
-
-  # Configure the chrony daemon for ntp
-  systemctl enable chronyd
-  sed -i -e "s/rhel/centos/" /etc/chrony.conf
-
-  for ntps in ${NTPServers//,/ }
-  do
-    echo "server ${ntps}" >> /etc/chrony.conf
-  done
 
   systemctl disable firewalld
 

--- a/src/mgmt/director.cfg
+++ b/src/mgmt/director.cfg
@@ -38,16 +38,16 @@ password password-changeme
 
 # CHANGEME: Change the IP and netmask below to the IP address, netmask and 
 # MTU for the Director VM on the Public API network
-eth0     192.168.190.13      255.255.255.0      1500
+enp1s0     192.168.190.13      255.255.255.0      1500
 
 # CHANGEME: Change the IP and netmask below to the IP address, netmask and
 # MTU for the Director VM on the Provisioning network
-eth1     192.168.120.13      255.255.255.0      1500
+enp2s0     192.168.120.13      255.255.255.0      1500
 
 # CHANGEME: Change the IP and netmask below to the IP address, netmask and
 # MTU for the Director VM on the Management network
-eth2     192.168.110.13      255.255.255.0      1500
+enp3s0     192.168.110.13      255.255.255.0      1500
 
 # CHANGEME: Change the IP and netmask below to the IP address, netmask and
 # MTU for the Director VM on the Private API network
-eth3     192.168.140.13      255.255.255.0      1500
+enp4s0     192.168.140.13      255.255.255.0      1500

--- a/src/mgmt/osp-sah.ks
+++ b/src/mgmt/osp-sah.ks
@@ -500,7 +500,8 @@ do
   echo "pool ${ntps}" >> /etc/chrony.conf
 done
 
-
+echo "local stratum 10" >> /etc/chrony.conf
+echo "manual" >> /etc/chrony.conf
 echo "allow ${NTPSettings}" >> /etc/chrony.conf
 echo "server 127.127.1.0" >> /etc/chrony.conf
 

--- a/src/pilot/containers-prepare-parameter.yaml
+++ b/src/pilot/containers-prepare-parameter.yaml
@@ -1,0 +1,22 @@
+# Generated with the following on 2019-11-25T11:49:03.206170
+#
+#   openstack tripleo container image prepare default --local-push-destination --output-env-file containers-prepare-parameter.yaml
+#
+
+parameter_defaults:
+  ContainerImagePrepare:
+  - push_destination: true
+    set:
+      ceph_image: rhceph-4-rhel8
+      ceph_namespace: registry.redhat.io/rhceph-beta
+      ceph_tag: latest
+      name_prefix: openstack-
+      name_suffix: ''
+      namespace: registry.redhat.io/rhosp15-rhel8
+      neutron_driver: ovn
+      tag: 15.0
+    tag_from_label: '{version}-{release}'
+
+  ContainerImageRegistryCredentials:
+    registry.redhat.io:
+      username: password

--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -154,11 +154,12 @@ sed -i "s/HOME/$ESCAPED_HOME/g" $HOME/pilot/undercloud.conf
 # Clean the nodes disks befor redeploying
 #sed -i "s/clean_nodes = false/clean_nodes = true/" $HOME/pilot/undercloud.conf
 cp $HOME/pilot/undercloud.conf $HOME
+cp $HOME/pilot/containers-prepare-parameter.yaml $HOME
 echo "## Done."
 
 echo
 echo "## Installing Director"
-run_command "sudo yum -y install python-tripleoclient"
+run_command "sudo yum -y install python3-tripleoclient"
 run_command "sudo yum install -y ceph-ansible"
 run_command "openstack undercloud install"
 echo "## Install Tempest plugin dependencies"

--- a/src/pilot/undercloud.conf
+++ b/src/pilot/undercloud.conf
@@ -1,75 +1,17 @@
-# Copyright (c) 2016-2019 Dell Inc. or its subsidiaries.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 [DEFAULT]
 
 #
-# From instack-undercloud
+# From undercloud_config
 #
 
 # Local file path to the necessary images. The path should be a
 # directory readable by the current user that contains the full set of
 # images. (string value)
-image_path = HOME/pilot/images
+image_path = /home/osp_admin/pilot/images
 
-# Fully qualified hostname (including domain) to set on the
-# Undercloud. If left unset, the current hostname will be used, but
-# the user is responsible for configuring all system hostname settings
-# appropriately.  If set, the undercloud install will configure all
-# system hostname settings. (string value)
-undercloud_hostname = CHANGEME e.g. director.openstack.lab
-
-# List of routed network subnets for provisioning and introspection.
-# Comma separated list of names/tags. For each network a section/group
-# needs to be added to the configuration file with these parameters
-# set: cidr, dhcp_start, dhcp_end, inspection_iprange, gateway and
-# masquerade_network.
-subnets = ctlplane-subnet
-local_subnet = ctlplane-subnet
-
-
-# IP information for the interface on the Undercloud that will be
-# handling the PXE boots and DHCP for Overcloud instances.  The IP
-# portion of the value will be assigned to the network interface
-# defined by local_interface, with the netmask defined by the prefix
-# portion of the value. (string value)
-local_ip = CHANGEME e.g. 192.168.120.13/24
-
-# List of ntp servers to use. (list value)
-undercloud_ntp_servers = CHANGEME e.g time.google.com 
-
-# Virtual IP address to use for the public endpoints of Undercloud
-# services. Only used with SSL. (string value)
-#undercloud_public_vip =
-
-# Virtual IP address to use for the admin endpoints of Undercloud
-# services. Only used with SSL. (string value)
-#undercloud_admin_vip =
-
-# Certificate file to use for OpenStack service SSL connections.
-# Setting this enables SSL for the OpenStack API endpoints, leaving it
-# unset disables SSL. (string value)
-#undercloud_service_certificate =
-
-# When set to True, an SSL certificate will be generated as part of
-# the undercloud install and this certificate will be used in place of
-# the value for undercloud_service_certificate.  The resulting
-# certificate will be written to
-# /etc/pki/tls/certs/undercloud-[undercloud_public_host].pem.  This
-# certificate is signed by CA selected by the
-# "certificate_generation_ca" option. (boolean value)
-#generate_service_certificate = false
+# List of additional architectures enabled in your cloud environment.
+# The list of supported values is: ppc64le (list value)
+#additional_architectures =
 
 # The certmonger nickname of the CA from which the certificate will be
 # requested. This is used only if the generate_service_certificate
@@ -79,89 +21,239 @@ undercloud_ntp_servers = CHANGEME e.g time.google.com
 # trust chain. (string value)
 #certificate_generation_ca = local
 
-# The kerberos principal for the service that will use the
-# certificate. This is only needed if your CA requires a kerberos
-# principal. e.g. with FreeIPA. (string value)
-#service_principal =
+# Whether to clean overcloud nodes (wipe the hard drive) between
+# deployments and after the introspection. (boolean value)
+clean_nodes = false
 
-# Network interface on the Undercloud that will be handling the PXE
-# boots and DHCP for Overcloud instances. (string value)
-local_interface = eth1
+# Cleanup temporary files. Setting this to False will leave the
+# temporary files used during deployment in place after the command is
+# run. This is useful for debugging the generated files or if errors
+# occur. (boolean value)
+#cleanup = true
 
-# MTU to use for the local_interface. (integer value)
-local_mtu = 1500
-
-
-# Network that will be masqueraded for external access, if required.
-# This should be the subnet used for PXE booting. (string value)
-masquerade_network = CHANGEME e.g. 192.168.120.0/24
-
-
-# Path to hieradata override file. If set, the file will be copied
-# under /etc/puppet/hieradata and set as the first file in the hiera
-# hierarchy. This can be used to to custom configure services beyond
-# what undercloud.conf provides (string value)
-#hieradata_override =
-
-# Path to network config override template. If set, this template will
-# be used to configure the networking via os-net-config. Must be in
-# json format. Templated tags can be used within the template, see
-# instack-undercloud/elements/undercloud-stack-config/net-
-# config.json.template for example tags (string value)
-#net_config_override =
-
-# Network interface on which inspection dnsmasq will listen.  If in
-# doubt, use the default value. (string value)
-# Deprecated group/name - [DEFAULT]/discovery_interface
-inspection_interface = br-ctlplane
-
-
-# Whether to enable extra hardware collection during the inspection
-# process. Requires python-hardware or python-hardware-detect package
-# on the introspection image. (boolean value)
-inspection_extras = true
-
-# Whether to run benchmarks when inspecting nodes. Requires
-# inspection_extras set to True. (boolean value)
-# Deprecated group/name - [DEFAULT]/discovery_runbench
-inspection_runbench = false
-
-# Whether to support introspection of nodes that have UEFI-only
-# firmware. (boolean value)
-inspection_enable_uefi = true
-
-# Whether to enable the debug log level for Undercloud OpenStack
-# services. (boolean value)
-undercloud_debug = true
-
-# Whether to install Tempest in the Undercloud. (boolean value)
-enable_tempest = true
-
-# Whether to install Mistral services in the Undercloud. (boolean
+# Container CLI used for deployment; Can be docker or podman. (string
 # value)
+container_cli = podman
+
+# Whether or not we disable the container healthchecks. (boolean
+# value)
+container_healthcheck_disabled = false
+
+# Heat environment file with parameters for all required container
+# images. Or alternatively, parameter "ContainerImagePrepare" to drive
+# the required image preparation. (string value)
+container_images_file = /home/osp_admin/containers-prepare-parameter.yaml
+
+# Used to add custom insecure registries for containers. (list value)
+# Deprecated group/name - [DEFAULT]/docker_insecure_registries
+#container_insecure_registries =
+
+# An optional container registry mirror that will be used. (string
+# value)
+# Deprecated group/name - [DEFAULT]/docker_registry_mirror
+#container_registry_mirror =
+
+# List of any custom environment yaml files to use. These are applied
+# after any other configuration and can be used to override any
+# derived values. This should be used only by advanced users. (list
+# value)
+#custom_env_files =
+
+# User used to run openstack undercloud install command which will be
+# used to add the user to the docker group, required to upload
+# containers (string value)
+#deployment_user = <None>
+
+# The default driver or hardware type to use for newly discovered
+# nodes (requires enable_node_discovery set to True). It is
+# automatically added to enabled_hardware_types. (string value)
+#discovery_default_driver = ipmi
+
+# DEPRECATED: Docker bridge IP for the undercloud. (string value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
+#docker_bip = --bip=172.31.0.1/24
+
+# Whether to install the Volume service. It is not currently used in
+# the undercloud. (boolean value)
+#enable_cinder = false
+
+# Whether to enable the ironic service. (boolean value)
+#enable_ironic = true
+
+# Whether to enable the ironic inspector service. (boolean value)
+#enable_ironic_inspector = true
+
+# Whether to enable the mistral service. (boolean value)
 enable_mistral = true
 
-# Whether to install Zaqar services in the Undercloud. (boolean value)
-enable_zaqar = true
+# Makes ironic-inspector enroll any unknown node that PXE-boots
+# introspection ramdisk in Ironic. By default, the "fake" driver is
+# used for new nodes (it is automatically enabled when this option is
+# set to True). Set discovery_default_driver to override.
+# Introspection rules can also be used to specify driver information
+# for newly enrolled nodes. (boolean value)
+#enable_node_discovery = false
 
-# Whether to install Telemetry services (ceilometer, aodh) in the
-# Undercloud. (boolean value)
+# Whether to install novajoin metadata service in the Undercloud.
+# (boolean value)
+#enable_novajoin = false
+
+# Enable support for routed ctlplane networks. (boolean value)
+#enable_routed_networks = false
+
+# Whether to enable Swift encryption at-rest or not. (boolean value)
+#enable_swift_encryption = false
+
+# Whether to install Telemetry services (ceilometer, gnocchi, aodh,
+# panko ) in the Undercloud. (boolean value)
 enable_telemetry = false
 
-# Whether to install the TripleO UI. (boolean value)
+# Whether to install Tempest in the Undercloud.This is a no-op for
+# containerized undercloud. (boolean value)
+enable_tempest = true
+
+# DEPRECATED: Whether to install the TripleO UI. (boolean value)
+# This option is deprecated for removal.
+# Its value may be silently ignored in the future.
 enable_ui = true
 
 # Whether to install requirements to run the TripleO validations.
 # (boolean value)
 enable_validations = true
 
-# Whether to use iPXE for deploy by default. (boolean value)
-ipxe_deploy = true
+# Whether to enable the zaqar service. (boolean value)
+enable_zaqar = true
 
+# List of enabled bare metal hardware types (next generation drivers).
+# (list value)
+#enabled_hardware_types = ipmi,redfish,ilo,idrac
 
-# Whether to store events in the Undercloud Ceilometer. (boolean
+# When set to True, an SSL certificate will be generated as part of
+# the undercloud install and this certificate will be used in place of
+# the value for undercloud_service_certificate.  The resulting
+# certificate will be written to
+# /etc/pki/tls/certs/undercloud-[undercloud_public_host].pem.  This
+# certificate is signed by CA selected by the
+# "certificate_generation_ca" option. (boolean value)
+#generate_service_certificate = true
+
+# URL for the heat container image to use. (string value)
+#heat_container_image =
+
+# Execute the heat-all process natively on this host. This option
+# requires that the heat-all binaries be installed locally on this
+# machine. This option is enabled by default which means heat-all is
+# executed on the host OS  directly. (boolean value)
+#heat_native = true
+
+# Path to hieradata override file. Relative paths get computed inside
+# of $HOME. When it points to a heat env file, it is passed in t-h-t
+# via "-e <file>", as is. When the file contains legacy instack data,
+# it is wrapped with UndercloudExtraConfig and also passed in for
+# t-h-t as a temp file created in output_dir. Note, instack hiera data
+# may be not t-h-t compatible and will highly likely require a manual
+# revision. (string value)
+#hieradata_override =
+
+# Whether to enable extra hardware collection during the inspection
+# process. Requires python-hardware or python-hardware-detect package
+# on the introspection image. (boolean value)
+inspection_extras = true
+
+# Network interface on which inspection dnsmasq will listen.  If in
+# doubt, use the default value. (string value)
+# Deprecated group/name - [DEFAULT]/discovery_interface
+inspection_interface = br-ctlplane
+
+# Whether to run benchmarks when inspecting nodes. Requires
+# inspection_extras set to True. (boolean value)
+# Deprecated group/name - [DEFAULT]/discovery_runbench
+inspection_runbench = false
+
+# One Time Password to register Undercloud node with an IPA server.
+# Required when enable_novajoin = True. (string value)
+#ipa_otp =
+
+# Whether to use iPXE for deploy and inspection. (boolean value)
+# Deprecated group/name - [DEFAULT]/ipxe_deploy
+ipxe_enabled = true
+
+# Network interface on the Undercloud that will be handling the PXE
+# boots and DHCP for Overcloud instances. (string value)
+local_interface = enp2s0
+
+# IP information for the interface on the Undercloud that will be
+# handling the PXE boots and DHCP for Overcloud instances.  The IP
+# portion of the value will be assigned to the network interface
+# defined by local_interface, with the netmask defined by the prefix
+# portion of the value. (string value)
+local_ip = CHANGEME e.g. 192.168.120.13/24
+
+# MTU to use for the local_interface. (integer value)
+local_mtu = 1500
+
+# Name of the local subnet, where the PXE boot and DHCP interfaces for
+# overcloud instances is located. The IP address of the
+# local_ip/local_interface should reside in this subnet. (string
 # value)
-store_events = false
+local_subnet = ctlplane-subnet
+
+# Path to network config override template.Relative paths get computed
+# inside of $HOME. Must be in the json format.Its content overrides
+# anything in t-h-t UndercloudNetConfigOverride. The processed
+# template is then passed in Heat via the undercloud_parameters.yaml
+# file created in output_dir and used to configure the networking via
+# run-os-net-config. If you wish to disable you can set this location
+# to an empty file.Templated for instack j2 tags may be used, for
+# example:
+#
+# "network_config": [
+#  {
+#   "type": "ovs_bridge",
+#   "name": "br-ctlplane",
+#   "ovs_extra": [
+#    "br-set-external-id br-ctlplane bridge-id br-ctlplane"
+#   ],
+#   "members": [
+#    {
+#     "type": "interface",
+#     "name": "{{LOCAL_INTERFACE}}",
+#     "primary": "true",
+#     "mtu": {{LOCAL_MTU}},
+#     "dns_servers": {{UNDERCLOUD_NAMESERVERS}}
+#    }
+#   ],
+#   "addresses": [
+#     {
+#       "ip_netmask": "{{PUBLIC_INTERFACE_IP}}"
+#     }
+#   ],
+#   "routes": {{SUBNETS_STATIC_ROUTES}},
+#   "mtu": {{LOCAL_MTU}}
+# }
+# ]
+#   (string value)
+#net_config_override =
+
+# Networks file to override for heat. May be an absolute path or the
+# path relative to the t-h-t templates directory used for deployment
+# (string value)
+#networks_file = <None>
+
+# Directory to output state, processed heat templates, ansible
+# deployment files. (string value)
+#output_dir = /builddir
+
+# DNS domain name to use when deploying the overcloud. The overcloud
+# parameter "CloudDomain" must be set to a matching value. (string
+# value)
+#overcloud_domain_name = localdomain
+
+# Roles file to override for heat. May be an absolute path or the path
+# relative to the t-h-t templates directory used for deployment
+# (string value)
+#roles_file = <None>
 
 # Maximum number of attempts the scheduler will make when deploying
 # the instance. You should keep it greater or equal to the number of
@@ -170,121 +262,83 @@ store_events = false
 # Minimum value: 1
 scheduler_max_attempts = 30
 
-# Whether to clean overcloud nodes (wipe the hard drive) between
-# deployments and after the introspection. (boolean value)
-clean_nodes = false
+# The kerberos principal for the service that will use the
+# certificate. This is only needed if your CA requires a kerberos
+# principal. e.g. with FreeIPA. (string value)
+#service_principal =
 
+# List of routed network subnets for provisioning and introspection.
+# Comma separated list of names/tags. For each network a section/group
+# needs to be added to the configuration file with these parameters
+# set: cidr, dhcp_start, dhcp_end, inspection_iprange, gateway and
+# masquerade_network. Note: The section/group must be placed before or
+# after any other section. (See the example section [ctlplane-subnet]
+# in the sample configuration file.) (list value)
+subnets = ctlplane-subnet
 
-[auth]
+# heat templates file to override. (string value)
+#templates =
 
-#
-# From instack-undercloud
-#
+# Virtual IP or DNS address to use for the admin endpoints of
+# Undercloud services. Only used with SSL. (string value)
+# Deprecated group/name - [DEFAULT]/undercloud_admin_vip
+#undercloud_admin_host = 192.168.24.3
 
-# Password used for MySQL databases. If left unset, one will be
-# automatically generated. (string value)
-#undercloud_db_password = <None>
+# Whether to enable the debug log level for Undercloud OpenStack
+# services and Container Image Prepare step. (boolean value)
+undercloud_debug = true
 
-# Keystone admin token. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_admin_token = <None>
+# Enable or disable SELinux during the deployment. (boolean value)
+#undercloud_enable_selinux = true
 
-# Keystone admin password. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_admin_password = <None>
+# Fully qualified hostname (including domain) to set on the
+# Undercloud. If left unset, the current hostname will be used, but
+# the user is responsible for configuring all system hostname settings
+# appropriately.  If set, the undercloud install will configure all
+# system hostname settings. (string value)
+undercloud_hostname = CHANGEME e.g. director.openstack.lab
 
-# Glance service password. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_glance_password = <None>
-
-# Heat db encryption key(must be 16, 24, or 32 characters. If left
-# unset, one will be automatically generated. (string value)
-#undercloud_heat_encryption_key = <None>
-
-# Heat service password. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_heat_password = <None>
-
-# Neutron service password. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_neutron_password = <None>
-
-# Nova service password. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_nova_password = <None>
-
-# Ironic service password. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_ironic_password = <None>
-
-# Aodh service password. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_aodh_password = <None>
-
-# Ceilometer service password. If left unset, one will be
-# automatically generated. (string value)
-#undercloud_ceilometer_password = <None>
-
-# Ceilometer metering secret. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_ceilometer_metering_secret = <None>
-
-# Ceilometer snmpd read-only user. If this value is changed from the
-# default, the new value must be passed in the overcloud environment
-# as the parameter SnmpdReadonlyUserName. This value must be between 1
-# and 32 characters long. (string value)
-#undercloud_ceilometer_snmpd_user = ro_snmp_user
-
-# Ceilometer snmpd password. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_ceilometer_snmpd_password = <None>
-
-# Swift service password. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_swift_password = <None>
-
-# Mistral service password. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_mistral_password = <None>
-
-# Rabbitmq cookie. If left unset, one will be automatically generated.
+# The path to a log file to store the undercloud install/upgrade logs.
 # (string value)
-#undercloud_rabbit_cookie = <None>
+#undercloud_log_file = install-undercloud.log
 
-# Rabbitmq password. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_rabbit_password = <None>
+# DNS nameserver(s). Use for the undercloud node and for the overcloud
+# nodes. (NOTE: To use different nameserver(s) for the overcloud,
+# override the DnsServers parameter in overcloud environment.) (list
+# value)
+undercloud_nameservers = CHANGEME e.g. 100.82.32.10
 
-# Rabbitmq username. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_rabbit_username = <None>
+# List of ntp servers to use. (list value)
+undercloud_ntp_servers = CHANGEME e.g time.google.com 
 
-# Heat stack domain admin password. If left unset, one will be
-# automatically generated. (string value)
-#undercloud_heat_stack_domain_admin_password = <None>
+# Virtual IP or DNS address to use for the public endpoints of
+# Undercloud services. Only used with SSL. (string value)
+# Deprecated group/name - [DEFAULT]/undercloud_public_vip
+#undercloud_public_host = 192.168.24.2
 
-# Swift hash suffix. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_swift_hash_suffix = <None>
+# Certificate file to use for OpenStack service SSL connections.
+# Setting this enables SSL for the OpenStack API endpoints, leaving it
+# unset disables SSL. (string value)
+#undercloud_service_certificate =
 
-# Sensu service password. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_sensu_password = <None>
+# Host timezone to be used. If no timezone is specified, the existing
+# timezone configuration is used. (string value)
+#undercloud_timezone = <None>
 
-# HAProxy stats password. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_haproxy_stats_password = <None>
+# Whether to update packages during the Undercloud install. This is a
+# no-op for containerized undercloud. (boolean value)
+#undercloud_update_packages = false
 
-# Zaqar password. If left unset, one will be automatically generated.
-# (string value)
-#undercloud_zaqar_password = <None>
-
-# Horizon secret key. If left unset, one will be automatically
-# generated. (string value)
-#undercloud_horizon_secret_key = <None>
+# (Experimental) Whether to clean undercloud rpms after an upgrade to
+# a containerized undercloud. (boolean value)
+#upgrade_cleanup = false
 
 
 [ctlplane-subnet]
+
+#
+# From undercloud_config
+#
 
 # Network CIDR for the Neutron-managed subnet for Overcloud instances.
 # (string value)
@@ -292,14 +346,19 @@ clean_nodes = false
 cidr = CHANGEME e.g. 192.168.120.0/24
 
 # Start of DHCP allocation range for PXE and DHCP of Overcloud
-# instances on this network. (string value)
+# instances on this network. (list value)
 # Deprecated group/name - [DEFAULT]/dhcp_start
 dhcp_start = CHANGEME e.g. 192.168.120.121
 
 # End of DHCP allocation range for PXE and DHCP of Overcloud instances
-# on this network. (string value)
+# on this network. (list value)
 # Deprecated group/name - [DEFAULT]/dhcp_end
 dhcp_end = CHANGEME e.g. 192.168.120.250
+
+# List of IP addresses or IP ranges to exclude from the subnets
+# allocation pool. Example: 192.168.24.50,192.168.24.80-192.168.24.90
+# (list value)
+#dhcp_exclude =
 
 # Temporary IP range that will be given to nodes on this network
 # during the inspection process. Should not overlap with the range
@@ -311,8 +370,16 @@ inspection_iprange = CHANGEME e.g. 192.168.120.21,192.168.120.120
 # Network gateway for the Neutron-managed network for Overcloud
 # instances on this network. (string value)
 # Deprecated group/name - [DEFAULT]/network_gateway
-gateway =  CHANGEME e.g. 192.168.120.13
+gateway = CHANGEME e.g. 192.168.120.13
+
+# Host routes for the Neutron-managed subnet for the Overcloud
+# instances on this network. The host routes on the local_subnet will
+# also be configured on the undercloud. (list value)
+#
+# This option has a sample default set, which means that
+# its actual default value may vary from the one documented
+# below.
+#host_routes = [{destination: 10.10.10.0/24, nexthop: 192.168.24.1}]
 
 # The network will be masqueraded for external access. (boolean value)
-#masquerade = false
-
+masquerade = true


### PR DESCRIPTION
Changes for deploying rhosp 15 undercloud have been included

1- A new undercloud.conf has been included
2- An additional file "src/pilot/containers-prepare-parameter.yaml" is needed while downloading container images. Include your "username: password" in this file before deployment. This feature will be automated in next PR
3- Chrony.conf is configured on SAH node with additional parameters to act like a local NTP server for overcloud and director