### PR TITLE
Increase timeout to wait for iDRAC reboot to finish after reset

### DIFF
--- a/src/pilot/config_idrac.py
+++ b/src/pilot/config_idrac.py
@@ -538,7 +538,7 @@ def clear_job_queue(drac_client, ip_service_tag):
 
 def reset_idrac(drac_client, ip_service_tag):
     LOG.info('Resetting the iDRAC on {}'.format(ip_service_tag))
-    drac_client.reset_idrac(wait=True)
+    drac_client.reset_idrac(wait=True, ready_wait_time=60)
 
 
 def config_idrac(instack_lock,


### PR DESCRIPTION
This patch does the stupid thing and bumps up the time to wait after an iDRAC becomes pingable after a reset to 60 seconds from 30 seconds.  A better fix will be implemented.