### PR TITLE
Change osd config to disk-by-path from lvm volumes

### DIFF
--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -532,9 +532,7 @@ class Director(InfraHost):
         uuid_to_osd_configs = json.loads(node_data_lookup_str)
         for uuid in uuid_to_osd_configs:
             osd_config = uuid_to_osd_configs[uuid]
-            num_osds = 0
-            for device in osd_config["lvm_volumes"]:
-                num_osds += 1
+            num_osds = len(osd_config["devices"])
             total_osds = total_osds + num_osds
 
         num_storage_nodes = len(self.settings.ceph_nodes)

--- a/src/pilot/assign_role.py
+++ b/src/pilot/assign_role.py
@@ -918,16 +918,16 @@ def generate_osd_config(ip_mac_service_tag, drac_client):
     new_osd_config = None
     if len(ssds) > 0 and len(spinners) == 0:
         # If we have an all flash config, then let Ceph colocate the journals
-        new_osd_config, mklvm = generate_osd_config_without_journals(controllers,
-                                                              ssds, system_id)
+        new_osd_config = generate_osd_config_without_journals(controllers,
+                                                              ssds)
     elif len(ssds) > 0 and len(spinners) > 0:
         # If we have a mix of flash and spinners, then use the ssds as journals
-        new_osd_config, mklvm = generate_osd_config_with_journals(controllers,
-                                                           spinners, ssds, system_id)
+        new_osd_config = generate_osd_config_with_journals(controllers,
+                                                           spinners, ssds)
     else:
         # We have all spinners, so let Ceph colocate the journals
-        new_osd_config, mklvm  = generate_osd_config_without_journals(controllers,
-                                                              spinners, system_id)
+        new_osd_config  = generate_osd_config_without_journals(controllers,
+                                                              spinners)
 
     # load the osd environment file
     osd_config_file = os.path.join(Constants.TEMPLATES, "ceph-osd-config.yaml")
@@ -1020,35 +1020,6 @@ def generate_osd_config(ip_mac_service_tag, drac_client):
         fcntl.flock(stream, fcntl.LOCK_UN)
         stream.close()
 
-    # Generate the mklvm script that ll create LVM's on firstboot
-
-    mklvm_file = os.path.join(Constants.TEMPLATES, "mklvm.sh")
-    streammklvm = open(mklvm_file, 'a+')
-
-    while True:
-        try:
-            fcntl.flock(streammklvm, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            break
-        except IOError as e:
-            if e.errno != errno.EAGAIN:
-                raise
-            else:
-                time.sleep(1)
-    try:
-        try:
-            current_mklvm = streammklvm.readlines()
-        except:
-            raise
-        streammklvm.seek(0)
-        streammklvm.writelines("%s\n" % line for line in mklvm)
-        streammklvm.truncate()
-
-    finally:
-        fcntl.flock(streammklvm, fcntl.LOCK_UN)
-        streammklvm.close()
-        
-
-
 def get_drives(drac_client):
     spinners = []
     ssds = []
@@ -1109,99 +1080,47 @@ def get_drives(drac_client):
 
     return spinners, ssds
 
-def generate_osd_config_without_journals(controllers, drives, system_id):
-    mklvm = []
-    mklvm.append('if [[ $(dmidecode -s system-uuid) == "' + system_id + '" ]]; then')
+def generate_osd_config_without_journals(controllers, osd_drives):
     osd_config = {
-        'osd_scenario': 'lvm',
-        'osd_objectstore': 'bluestore',
-        'lvm_volumes': []}
-    drive_count = 0
-    for osd_drive in drives:
+        'osd_scenario': 'collocated',
+        'devices': []}
+    for osd_drive in osd_drives:
         osd_drive_device_name = get_by_path_device_name(
             osd_drive, controllers)
-        mklvm.append('  device=$(ls -la ' + osd_drive_device_name + " |  awk -F \"../../\" '{ print $2 }')")
-        mklvm.append('  eval "wipefs -a /dev/${device}"')
-        mklvm.append('  sleep 2')
-        mklvm.append('  pvcreate ' + osd_drive_device_name)
-        mklvm.append('  vgcreate ceph_vg' + str(drive_count) + ' ' + osd_drive_device_name)
-        mklvm.append("  size=$(sudo fdisk -l /dev/${device} 2>/dev/null | grep -m1 \"Disk\" | awk '{print $5}')")
-        mklvm.append("  sizeb=`expr $((${size} * 99 / 100))`")
-        mklvm.append("  sizeb=`expr $((${sizeb} / 512 * 512))`")
-        mklvm.append('  lvcreate -n ceph_lv' + str(drive_count) + '_data -L ${sizeb}B ceph_vg' + str(drive_count))
-        mklvm.append('  sleep 2')
-        osd_config['lvm_volumes'].append({"data": "ceph_lv" + str(drive_count) + "_data",
-                                      "data_vg": "ceph_vg" + str(drive_count)})
-        drive_count += 1
-    mklvm.append("fi")
-    return osd_config, mklvm
+        osd_config['devices'].append(osd_drive_device_name)
 
-def generate_osd_config_with_journals(controllers, osd_drives, ssds, system_id):
+    return osd_config
+
+def generate_osd_config_with_journals(controllers, osd_drives, ssds):
     if len(osd_drives) % len(ssds) != 0:
         LOG.warning("There is not an even mapping of OSD drives to SSD "
                     "journals.  This will cause inconsistent performance "
                     "characteristics.")
-    mklvm = []
-    mklvm.append('if [[ $(dmidecode -s system-uuid) == "' + system_id + '" ]]; then')
+
     osd_config = {
-        'osd_scenario': 'lvm',
-        'osd_objectstore': 'bluestore',
-        'lvm_volumes': []}
+        'osd_scenario': 'non-collocated',
+        'devices': [],
+        'dedicated_devices': []}
     osd_index = 0
-    vg_index = 0
     remaining_ssds = len(ssds)
     for ssd in ssds:
         ssd_device_name = get_by_path_device_name(ssd, controllers)
 
         num_osds_for_ssd = int(math.ceil((len(osd_drives)-osd_index) /
                                          (remaining_ssds * 1.0)))
-        # x2 volumes for each data osd (DB & WAL)
-        allocation_journals = 50 / num_osds_for_ssd - 1
-        mklvm.append('  device=$(ls -la ' + ssd_device_name + " |  awk -F \"../../\" '{ print $2 }')")
-        mklvm.append('  eval "wipefs -a /dev/${device}"')
-        mklvm.append('  sleep 2')
-        mklvm.append('  pvcreate ' + ssd_device_name)
-        mklvm.append('  vgcreate ceph_vg' + str(vg_index) + ' ' + ssd_device_name)
-        mklvm.append("  size=$(sudo fdisk -l /dev/${device} 2>/dev/null | grep -m1 \"Disk\" | awk '{print $5}')")
-        mklvm.append("  siz=`expr $((${size} * " + str(allocation_journals) + " / 100))`")
-        mklvm.append("  siz=`expr $((${siz} / 512 * 512))`")
-        for i in range(0, num_osds_for_ssd):
-            mklvm.append('  lvcreate -n ceph_lv' + str(vg_index) + "-" + str(i) + '_wal -L ${siz}B ceph_vg' + str(vg_index))
-            mklvm.append('  lvcreate -n ceph_lv' + str(vg_index) + "-" + str(i) + '_db -L ${siz}B ceph_vg' + str(vg_index))
-            mklvm.append('  sleep 2')
 
         osds_for_ssd = osd_drives[osd_index:
                                   osd_index + num_osds_for_ssd]
-        ind = 0
-        journal_index = vg_index
         for osd_drive in osds_for_ssd:
-            vg_index += 1
             osd_drive_device_name = get_by_path_device_name(
                 osd_drive, controllers)
-            mklvm.append('  device=$(ls -la ' + osd_drive_device_name + " |  awk -F \"../../\" '{ print $2 }')")
-            mklvm.append('  eval "wipefs -a /dev/${device}"')
-            mklvm.append('  sleep 2')
-            mklvm.append('  pvcreate ' + osd_drive_device_name)
-            mklvm.append('  vgcreate ceph_vg' + str(vg_index) + ' ' + osd_drive_device_name)
-            mklvm.append("  size=$(sudo fdisk -l /dev/${device} 2>/dev/null | grep -m1 \"Disk\" | awk '{print $5}')")
-            mklvm.append("  sizeb=`expr $((${size} * 99 / 100))`")
-            mklvm.append("  sizeb=`expr $((${sizeb} / 512 * 512))`")
-            mklvm.append('  lvcreate -n ceph_lv' + str(vg_index) + '_data -L ${sizeb}B ceph_vg' + str(vg_index))
-            mklvm.append('  sleep 2')
-            osd_config['lvm_volumes'].append({"data": "ceph_lv" + str(vg_index) + "_data",
-                                      "data_vg": "ceph_vg" + str(vg_index),
-                                      "db": "ceph_lv" + str(journal_index) + "-" + str(ind) + "_db",
-                                      "db_vg": "ceph_vg" + str(journal_index),
-                                      "wal": "ceph_lv" + str(journal_index) +  "-" + str(ind) + "_wal",
-                                      "wal_vg": "ceph_vg" + str(journal_index)})
-            ind += 1
+
+            osd_config['devices'].append(osd_drive_device_name)
+            osd_config['dedicated_devices'].append(ssd_device_name)
         osd_index += num_osds_for_ssd
         remaining_ssds -= 1
-        vg_index += 1
-    mklvm.append("fi")
 
-    return osd_config, mklvm
-
+    return osd_config
 
 def get_by_path_device_name(physical_disk, controllers):
     if physical_disk.description.startswith("Virtual Disk"):


### PR DESCRIPTION
Hi Chris,

As discuss we have reverted  back osd configuration through disk/by-path instead of lvm_volumes.
Also we perform one round of overcloud deployment in which its successfully creates osds and in the end stack creates without failure.

Please have a look.

-Rachit