### PR TITLE
Nights watch model PXE NIC update

### DIFF
--- a/src/pilot/dell_systems.json
+++ b/src/pilot/dell_systems.json
@@ -33,7 +33,7 @@
     "pxe_nic": "NIC.Integrated.1-1-1"
   },
   "PowerEdge XE2420": {
-    "pxe_nic": "NIC.Slot.4-1-1"
+    "pxe_nic": "NIC.Mezzanine.1-1-1"
   },
   "DSS 9600": {
     "pxe_nic": "NIC.Mezzanine.3-1-1"


### PR DESCRIPTION
The pxe_nic slot has changed since we acquired the OCP cards for the XE2420 (Nights Watch).