### PR TITLE
RHOSP16 repo update, overcloud deploy command update

### DIFF
--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -776,8 +776,8 @@ class Director(InfraHost):
     def setup_dell_storage(self):
 
         # Clean the local docker registry
-        if len(self.run_tty("sudo docker images -a -q")[0]) > 1:
-            self.run_tty("sudo docker rmi $(sudo docker images -a -q) --force")
+        #if len(self.run_tty("sudo docker images -a -q")[0]) > 1:
+            #self.run_tty("sudo docker rmi $(sudo docker images -a -q) --force")
 
         # Re - Upload the yaml files in case we're trying to
         # leave the undercloud intact but want to redeploy with

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -565,7 +565,7 @@ enable_version_locking=false
 # Note that this parameter is defaulted as shown below when commented out or
 # not specified.  It should not be necessary to change it from the default in
 # most cases.
-rhsm_repos=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-highavailability-rpms,ansible-2.8-for-rhel-8-x86_64-rpms,advanced-virt-for-rhel-8-x86_64-rpms,satellite-tools-6.5-for-rhel-8-x86_64-rpms,openstack-beta-for-rhel-8-x86_64-rpms,fast-datapath-for-rhel-8-x86_64-rpms
+rhsm_repos=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-highavailability-rpms,ansible-2.8-for-rhel-8-x86_64-rpms,advanced-virt-for-rhel-8-x86_64-rpms,satellite-tools-6.5-for-rhel-8-x86_64-rpms,openstack-16-for-rhel-8-x86_64-rpms,fast-datapath-for-rhel-8-x86_64-rpms
 
 # Option below is to use a custom instack.json and skip discover_nodes
 use_custom_instack_json=false

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -564,7 +564,7 @@ enable_version_locking=false
 # Note that this parameter is defaulted as shown below when commented out or
 # not specified.  It should not be necessary to change it from the default in
 # most cases.
-rhsm_repos=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-highavailability-rpms,ansible-2.8-for-rhel-8-x86_64-rpms,advanced-virt-for-rhel-8-x86_64-rpms,satellite-tools-6.5-for-rhel-8-x86_64-rpms,openstack-beta-for-rhel-8-x86_64-rpms,fast-datapath-for-rhel-8-x86_64-rpms
+rhsm_repos=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-highavailability-rpms,ansible-2.8-for-rhel-8-x86_64-rpms,advanced-virt-for-rhel-8-x86_64-rpms,satellite-tools-6.5-for-rhel-8-x86_64-rpms,openstack-16-for-rhel-8-x86_64-rpms,fast-datapath-for-rhel-8-x86_64-rpms
 
 # Option below is to use a custom instack.json and skip discover_nodes
 use_custom_instack_json=false

--- a/src/mgmt/deploy-director-vm.sh
+++ b/src/mgmt/deploy-director-vm.sh
@@ -218,7 +218,7 @@ EOFPW
          subscription-manager attach --auto ${ProxyInfo}
          )
 
-  subscription-manager repos ${ProxyInfo} '--disable=*' --enable=rhel-8-for-x86_64-baseos-rpms --enable=rhel-8-for-x86_64-appstream-rpms --enable=rhel-8-for-x86_64-highavailability-rpms --enable=ansible-2.8-for-rhel-8-x86_64-rpms --enable=advanced-virt-for-rhel-8-x86_64-rpms --enable=satellite-tools-6.5-for-rhel-8-x86_64-rpms --enable=openstack-beta-for-rhel-8-x86_64-rpms --enable=fast-datapath-for-rhel-8-x86_64-rpms
+  subscription-manager repos ${ProxyInfo} '--disable=*' --enable=rhel-8-for-x86_64-baseos-rpms --enable=rhel-8-for-x86_64-appstream-rpms --enable=rhel-8-for-x86_64-highavailability-rpms --enable=ansible-2.8-for-rhel-8-x86_64-rpms --enable=advanced-virt-for-rhel-8-x86_64-rpms --enable=satellite-tools-6.5-for-rhel-8-x86_64-rpms --enable=openstack-16-for-rhel-8-x86_64-rpms --enable=fast-datapath-for-rhel-8-x86_64-rpms
 
   mkdir /tmp/mnt
   mount /dev/fd0 /tmp/mnt

--- a/src/pilot/containers-prepare-parameter.yaml
+++ b/src/pilot/containers-prepare-parameter.yaml
@@ -13,7 +13,8 @@ parameter_defaults:
       name_prefix: openstack-
       name_suffix: ''
       namespace: registry.redhat.io/rhosp-beta
-      neutron_driver: ovn
+# Use Null value for standard neutron-container and use ovn for OVN-based-container
+      neutron_driver:
       tag: 16.0
     tag_from_label: '{version}-{release}'
 

--- a/src/pilot/deploy-overcloud.py
+++ b/src/pilot/deploy-overcloud.py
@@ -540,7 +540,7 @@ def main():
         # storage-environment.yaml and ceph-radosgw.yaml
         env_opts += " -e ~/pilot/templates/overcloud/environments/" \
                     "storage-environment.yaml" \
-                    " -e ~/overcloud_images.yaml" \
+                    " -e ~/containers-prepare-parameter.yaml" \
                     " -e ~/pilot/templates/dell-environment.yaml" 
         host_config = False
         if args.enable_hugepages or args.enable_numa:


### PR DESCRIPTION
Includes:
1. OSP 16 rpms updated
2. Added instructions on pulling OVN/OVS based neutron-container
3. overcloud_images.yaml is deprecated, replaced by containers-prepare-parameter.yaml