### PR TITLE
Removed comma at the end of the line

### DIFF
--- a/src/pilot/dracclient_raid.patch
+++ b/src/pilot/dracclient_raid.patch
@@ -63,7 +63,7 @@
                                                         uri)
          drac_bus_protocol = self._get_physical_disk_attr(drac_disk,
 -                                                         'BusProtocol', uri)
-+                                                         'BusProtocol', uri),
++                                                         'BusProtocol', uri)
 +        bus = self._get_physical_disk_attr(drac_disk,
 +                                           'Bus', uri,  allow_missing=True)
 +


### PR DESCRIPTION
Hi Chris,

There was one typo error which was failing the deployment. It is resolved now. I also checked to upstream python-dracclient code which is clean. 
It was very hard to catch :)  Apologies..!

Thanks and Regards,
Rachit