### PR TITLE
YAQL expression parsing error fix

### DIFF
--- a/src/pilot/dell_nfv.py
+++ b/src/pilot/dell_nfv.py
@@ -229,11 +229,11 @@ class ConfigOvercloud(object):
                 cmds.append(
                     'sed -i "s|# NovaVcpuPinSet:.*|NovaVcpuPinSet: ' +
                     self.nfv_params.nova_cpus + '|" ' + file_path)
-            cmds.append(
-                'sed -i "s|# DellComputeParameters:' +
-                '|DellComputeParameters:|" ' +
-                file_path)
             if kernel_args:
+                cmds.append(
+                    'sed -i "s|# DellComputeParameters:' +
+                    '|DellComputeParameters:|" ' +
+                    file_path)
                 cmds.append(
                     'sed -i "s|# KernelArgs:.*|KernelArgs: \\"' +
                     kernel_args + '\\" |" ' + file_path)


### PR DESCRIPTION
Empty DellComputeParameters section was causing YAQL expression error during overcloud deployment. Now this DellComputeParameters section will only be used when we are setting KernelArgs parameter.