### PR TITLE
Fix node cfg bool attrs

### DIFF
--- a/src/deploy/osp_deployer/deployer.py
+++ b/src/deploy/osp_deployer/deployer.py
@@ -53,10 +53,6 @@ def get_settings():
                         help='Do not reinstall the Dashboard VM',
                         action='store_true',
                         required=False)
-    parser.add_argument('-skip_idrac_config', '--skip_idrac_config',
-                        help='Skip configuring iDRACs',
-                        action='store_true',
-                        required=False)
     group = parser.add_mutually_exclusive_group()
     group.add_argument('-validate_only', '--validate_only',
                        help='No deployment - just validate config values',
@@ -111,8 +107,6 @@ def deploy():
                 logger.info("Only redeploying the overcloud")
             if args.skip_dashboard_vm is True:
                 logger.info("Skipping Dashboard VM install")
-            if args.skip_idrac_config is True:
-                logger.info("Skipping iDRAC configuration")
 
         logger.info("Settings .ini: " + settings.settings_file)
         logger.info("Settings .properties " + settings.network_conf)
@@ -221,8 +215,7 @@ def deploy():
         director_vm.setup_net_envt()
         director_vm.configure_dhcp_server()
         director_vm.node_discovery()
-        if args.skip_idrac_config is False:
-            director_vm.configure_idracs()
+        director_vm.configure_idracs()
         director_vm.import_nodes()
         director_vm.node_introspection()
         director_vm.update_sshd_conf()

--- a/src/deploy/osp_deployer/settings/config.py
+++ b/src/deploy/osp_deployer/settings/config.py
@@ -716,70 +716,82 @@ class Settings():
             for each in json_data:
                 node = NodeConf(each)
                 try:
-                    if node.is_sah == "true":
+                    node.is_sah = (True if node.is_sah
+                                   == "true" else False)
+                    if node.is_sah:
                         self.sah_node = node
                 except AttributeError:
                     pass
                 try:
-                    if node.is_director == "true":
+                    node.is_director = (True if node.is_director
+                                        == "true" else False)
+                    if node.is_director:
                         self.director_node = node
                 except AttributeError:
                     pass
                 try:
-                    if node.is_dashboard == "true":
+                    node.is_dashboard = (True if node.is_dashboard
+                                         == "true" else False)
+                    if node.is_dashboard:
                         self.dashboard_node = node
                 except AttributeError:
                     pass
                 try:
-                    if node.is_controller == "true":
-                        node.is_controller = True
+                    node.is_controller = (True if node.is_controller
+                                          == "true" else False)
+                    if node.is_controller:
                         self.controller_nodes.append(node)
                 except AttributeError:
                     node.is_controller = False
                     pass
                 try:
-                    if node.is_computehci == "true":
-                        node.is_computehci = True
+                    node.is_computehci = (True if node.is_computehci
+                                          == "true" else False)
+                    if node.is_computehci:
                         self.computehci_nodes.append(node)
                 except AttributeError:
                     node.is_computehci = False
                     pass
 
                 try:
-                    if node.is_compute == "true":
-                        node.is_compute = True
+                    node.is_compute = (True if node.is_compute
+                                       == "true" else False)
+                    if node.is_compute:
                         self.compute_nodes.append(node)
                 except AttributeError:
                     node.is_compute = False
                     pass
                 try:
-                    if node.is_ceph_storage == "true":
+                    node.is_storage = (True if node.is_ceph_storage
+                                       == "true" else False)
+                    if node.is_storage:
                         self.ceph_nodes.append(node)
-                        node.is_storage = True
                 except AttributeError:
                     node.is_storage = False
                     pass
                 try:
-                    if node.is_switch == "true":
+                    node.is_switch = (True if node.is_switch
+                                      == "true" else False)
+                    if node.is_switch:
                         self.switches.append(node)
                 except AttributeError:
                     self.nodes.append(node)
                     pass
                 try:
-                    if node.skip_raid_config == "true":
-                        node.skip_raid_config = True
+                    node.skip_raid_config = (True if node.skip_raid_config
+                                             == "true" else False)
                 except AttributeError:
                     node.skip_raid_config = False
                     pass
                 try:
-                    if node.skip_bios_config == "true":
-                        node.skip_bios_config = True
+                    node.skip_bios_config = (True if node.skip_bios_config
+                                             == "true" else False)
                 except AttributeError:
                     node.skip_bios_config = False
                     pass
                 try:
-                    if node.skip_nic_config == "true":
-                        node.skip_nic_config = True
+                    node.skip_nic_config = (True if node.skip_nic_config
+                                            == "true" else False)
                 except AttributeError:
                     node.skip_nic_config = False
                     pass


### PR DESCRIPTION
If some boolean node attributes are set to false instead of being omitted from the node configuration, the values are interpreted as True.  For instance if there is node configuration of:
    {
        "is_controller": "true",
        "pxe_nic": "NIC.Integrated.1-3-1",
        "idrac_ip": "192.168.110.13",
         ...
        "skip_raid_config": "false",
        "skip_nic_config": "false"
    },

is node.skip_raid_config:  <- will be interpreted as true.

Fixed by using ternary operator in config.py so booleans are are always set to python booleans instead of strings:
try:
    **node.skip_raid_config = (True if node.skip_raid_config
                                             == "true" else False)**
except AttributeError:
     node.skip_raid_config = False
     pass
