### PR TITLE
Added monkey patches for e-HBA feature and its bug fix

### DIFF
--- a/src/pilot/client.patch
+++ b/src/pilot/client.patch
@@ -1,5 +1,5 @@
---- /usr/lib/python2.7/site-packages/dracclient/client.py	2019-11-14 19:39:49.304541029 +0000
-+++ client.py.new	2019-11-14 19:39:24.639089436 +0000
+--- client.py.orig	2019-06-03 23:56:04.000000000 -0500
++++ client_new.py	2020-05-06 07:44:40.121131696 -0500
 @@ -33,7 +33,7 @@
  from dracclient import utils
  from dracclient import wsman
@@ -156,7 +156,51 @@
      def get_lifecycle_controller_version(self):
          """Returns the Lifecycle controller version
  
-@@ -788,6 +876,50 @@
+@@ -674,6 +762,43 @@
+         """
+         return self._raid_mgmt.list_raid_controllers()
+ 
++    def list_raid_settings(self):
++        """List the RAID configuration settings
++
++        :returns: a dictionary with the RAID settings using InstanceID as the
++                  key. The attributes are either RAIDEnumerableAttribute,
++                  RAIDStringAttribute objects.
++        :raises: WSManRequestFailure on request failures
++        :raises: WSManInvalidResponse when receiving invalid response
++        :raises: DRACOperationFailed on error reported back by the DRAC
++                 interface
++        """
++        return self._raid_mgmt.list_raid_settings()
++
++    def set_raid_settings(self, raid_fqdd, settings):
++        """Sets the RAID configuration
++
++        It sets the pending_value parameter for each of the attributes
++        passed in. For the values to be applied, a config job must
++        be created.
++        :param raid_fqdd: the FQDD of the RAID setting.
++        :param settings: a dictionary containing the proposed values, with
++                         each key being the name of attribute and the value
++                         being the proposed value.
++        :returns: a dictionary containing:
++                 - The is_commit_required key with a boolean value indicating
++                   whether a config job must be created for the values to be
++                   applied.
++                 - The is_reboot_required key with a RebootRequired enumerated
++                   value indicating whether the server must be rebooted for the
++                   values to be applied. Possible values are true and false.
++        :raises: WSManRequestFailure on request failures
++        :raises: WSManInvalidResponse when receiving invalid response
++        :raises: DRACOperationFailed on error reported back by the DRAC
++                 interface
++        """
++        return self._raid_mgmt.set_raid_settings(raid_fqdd, settings)
++
+     def list_virtual_disks(self):
+         """Returns the list of RAID arrays
+ 
+@@ -788,6 +913,50 @@
          """
          return self._raid_mgmt.delete_virtual_disk(virtual_disk)
  
@@ -207,13 +251,12 @@
      def commit_pending_raid_changes(self, raid_controller, reboot=False,
                                      start_time='TIME_NOW', realtime=False):
          """Applies all pending changes on a RAID controller
-@@ -1015,32 +1147,33 @@
+@@ -1015,32 +1184,33 @@
  
      def change_physical_disk_state(self, mode,
                                     controllers_to_physical_disk_ids=None):
 -        """Convert disks RAID status and return a list of controller IDs
-+        """Convert disks RAID status
- 
+-
 -        Builds a list of controller ids that have had disks converted to the
 -        specified RAID status by:
 -        - Examining all the disks in the system and filtering out any that are
@@ -224,13 +267,14 @@
 -          statuses and raise an exception where appropriate.
 -        - Return a list of controller IDs for controllers whom have had any of
 -          their disks converted, and whether a reboot is required.
++        """Convert disks RAID status
+ 
+-        The caller typically should then create a config job for the list of
+-        controllers returned to finalize the RAID configuration.
 +        This method intelligently converts the requested physical disks from
 +        RAID to JBOD or vice versa.  It does this by only converting the
 +        disks that are not already in the correct state.
  
--        The caller typically should then create a config job for the list of
--        controllers returned to finalize the RAID configuration.
--
 -        :param mode: constants.RaidStatus enumeration used to determine what
 -                     raid status to check for.
 +        :param mode: constants.RaidStatus enumeration that indicates the mode
@@ -262,7 +306,7 @@
          :raises: DRACOperationFailed on error reported back by the DRAC and the
                   exception message does not contain NOT_SUPPORTED_MSG constant.
          :raises: Exception on unknown error.
-@@ -1202,11 +1335,11 @@
+@@ -1202,11 +1372,11 @@
                               expected_return_value=utils.RET_SUCCESS,
                               wait_for_idrac=False)
  

--- a/src/pilot/dracclient_raid.patch
+++ b/src/pilot/dracclient_raid.patch
@@ -1,5 +1,5 @@
---- raid.py.orig	2019-06-04 04:56:04.000000000 +0000
-+++ raid_modified.py	2020-02-17 11:58:54.234844526 +0000
+--- raid.py.orig	2019-06-03 23:56:04.000000000 -0500
++++ raid_new.py	2020-05-06 07:51:39.732602457 -0500
 @@ -12,6 +12,7 @@
  #    under the License.
  
@@ -8,7 +8,7 @@
  import logging
  
  from dracclient import constants
-@@ -81,7 +82,10 @@
+@@ -81,7 +82,283 @@
      ['id', 'description', 'controller', 'manufacturer', 'model', 'media_type',
       'interface_type', 'size_mb', 'free_size_mb', 'serial_number',
       'firmware_version', 'status', 'raid_status', 'sas_address',
@@ -17,10 +17,283 @@
 +
 +
 +NO_FOREIGN_DRIVES = ["STOR058", "STOR018"]
++
++
++
++class RAIDAttribute(object):
++    """Generic RAID attribute class"""
++
++    def __init__(self, name, instance_id, current_value, pending_value,
++                 read_only, fqdd):
++        """Creates RAIDAttribute object
++
++        :param name: name of the RAID attribute
++        :param instance_id: InstanceID of the RAID attribute
++        :param current_value: list containing the current values of the
++                RAID attribute
++        :param pending_value: pending value of the RAID attribute, reflecting
++                an unprocessed change (eg. config job not completed)
++        :param read_only: indicates whether this RAID attribute can be changed
++        :param fqdd: Fully Qualified Device Description of the RAID Attribute
++        """
++
++        self.name = name
++        self.instance_id = instance_id
++        self.current_value = current_value
++        self.pending_value = pending_value
++        self.read_only = read_only
++        self.fqdd = fqdd
++
++    def __eq__(self, other):
++        return self.__dict__ == other.__dict__
++
++    @classmethod
++    def parse(cls, namespace, raid_attr_xml):
++        """Parses XML and creates RAIDAttribute object"""
++
++        name = utils.get_wsman_resource_attr(
++            raid_attr_xml, namespace, 'AttributeName')
++        instance_id = utils.get_wsman_resource_attr(
++            raid_attr_xml, namespace, 'InstanceID')
++        current_value = [attr.text for attr in
++                         utils.find_xml(raid_attr_xml, 'CurrentValue',
++                                        namespace, find_all=True)]
++        pending_value = utils.get_wsman_resource_attr(
++            raid_attr_xml, namespace, 'PendingValue', nullable=True)
++        read_only = utils.get_wsman_resource_attr(
++            raid_attr_xml, namespace, 'IsReadOnly')
++        fqdd = utils.get_wsman_resource_attr(
++            raid_attr_xml, namespace, 'FQDD')
++
++        return cls(name, instance_id, current_value, pending_value,
++                   (read_only == 'true'), fqdd)
++
++
++class RAIDEnumerableAttribute(RAIDAttribute):
++    """Enumerable RAID attribute class"""
++
++    namespace = uris.DCIM_RAIDEnumeration
++
++    def __init__(self, name, instance_id, current_value, pending_value,
++                 read_only, fqdd, possible_values):
++        """Creates RAIDEnumerableAttribute object
++
++        :param name: name of the RAID attribute
++        :param instance_id: InstanceID of the RAID attribute
++        :param current_value: list containing the current values of the
++                RAID attribute
++        :param pending_value: pending value of the RAID attribute, reflecting
++                an unprocessed change (eg. config job not completed)
++        :param read_only: indicates whether this RAID attribute can be changed
++        :param fqdd: Fully Qualified Device Description of the RAID
++                Attribute
++        :param possible_values: list containing the allowed values for the RAID
++                attribute
++        """
++        super(RAIDEnumerableAttribute, self).__init__(name, instance_id,
++                                                      current_value,
++                                                      pending_value,
++                                                      read_only, fqdd)
++
++        self.possible_values = possible_values
++
++    @classmethod
++    def parse(cls, raid_attr_xml):
++        """Parses XML and creates RAIDEnumerableAttribute object"""
++
++        raid_attr = RAIDAttribute.parse(cls.namespace, raid_attr_xml)
++        possible_values = [attr.text for attr
++                           in utils.find_xml(raid_attr_xml,
++                                             'PossibleValues',
++                                             cls.namespace, find_all=True)]
++
++        return cls(raid_attr.name, raid_attr.instance_id,
++                   raid_attr.current_value, raid_attr.pending_value,
++                   raid_attr.read_only, raid_attr.fqdd, possible_values)
++
++    def validate(self, new_value):
++        """Validates new value"""
++
++        if str(new_value) not in self.possible_values:
++            msg = ("Attribute '%(attr)s' cannot be set to value '%(val)s'."
++                   " It must be in %(possible_values)r.") % {
++                   'attr': self.name,
++                   'val': new_value,
++                   'possible_values': self.possible_values}
++            return msg
++
++
++class RAIDStringAttribute(RAIDAttribute):
++    """String RAID attribute class"""
++
++    namespace = uris.DCIM_RAIDString
++
++    def __init__(self, name, instance_id, current_value, pending_value,
++                 read_only, fqdd, min_length, max_length):
++        """Creates RAIDStringAttribute object
++
++        :param name: name of the RAID attribute
++        :param instance_id: InstanceID of the RAID attribute
++        :param current_value:  list containing the current values of the
++                RAID attribute
++        :param pending_value: pending value of the RAID attribute, reflecting
++                an unprocessed change (eg. config job not completed)
++        :param read_only: indicates whether this RAID attribute can be changed
++        :param fqdd: Fully Qualified Device Description of the RAID
++                Attribute
++        :param min_length: minimum length of the string
++        :param max_length: maximum length of the string
++        """
++        super(RAIDStringAttribute, self).__init__(name, instance_id,
++                                                  current_value, pending_value,
++                                                  read_only, fqdd)
++        self.min_length = min_length
++        self.max_length = max_length
++
++    @classmethod
++    def parse(cls, raid_attr_xml):
++        """Parses XML and creates RAIDStringAttribute object"""
++
++        raid_attr = RAIDAttribute.parse(cls.namespace, raid_attr_xml)
++        min_length = int(utils.get_wsman_resource_attr(
++            raid_attr_xml, cls.namespace, 'MinLength'))
++        max_length = int(utils.get_wsman_resource_attr(
++            raid_attr_xml, cls.namespace, 'MaxLength'))
++
++        return cls(raid_attr.name, raid_attr.instance_id,
++                   raid_attr.current_value, raid_attr.pending_value,
++                   raid_attr.read_only, raid_attr.fqdd,
++                   min_length, max_length)
++
++
++class RAIDIntegerAttribute(RAIDAttribute):
++    """Integer RAID attribute class"""
++
++    namespace = uris.DCIM_RAIDInteger
++
++    def __init__(self, name, instance_id, current_value, pending_value,
++                 read_only, fqdd, lower_bound, upper_bound):
++        """Creates RAIDIntegerAttribute object
++
++        :param name: name of the RAID attribute
++        :param instance_id: InstanceID of the RAID attribute
++        :param current_value: list containing the current value of the
++                RAID attribute
++        :param pending_value: pending value of the RAID attribute,
++                reflecting an unprocessed change
++                (eg. config job not completed)
++        :param read_only: indicates whether this RAID attribute can be
++                changed
++        :param fqdd: Fully Qualified Device Description of the RAID
++                Attribute
++        :param lower_bound: minimum value for the RAID attribute
++        :param upper_bound: maximum value for the RAID attribute
++        """
++        super(RAIDIntegerAttribute, self).__init__(name, instance_id,
++                                                   current_value,
++                                                   pending_value,
++                                                   read_only, fqdd)
++        self.lower_bound = lower_bound
++        self.upper_bound = upper_bound
++
++    @classmethod
++    def parse(cls, raid_attr_xml):
++        """Parses XML and creates RAIDIntegerAttribute object"""
++
++        raid_attr = RAIDAttribute.parse(cls.namespace, raid_attr_xml)
++        lower_bound = utils.get_wsman_resource_attr(
++            raid_attr_xml, cls.namespace, 'LowerBound')
++        upper_bound = utils.get_wsman_resource_attr(
++            raid_attr_xml, cls.namespace, 'UpperBound')
++
++        if raid_attr.current_value:
++            raid_attr.current_value = int(raid_attr.current_value[0])
++        if raid_attr.pending_value:
++            raid_attr.pending_value = int(raid_attr.pending_value)
++
++        return cls(raid_attr.name, raid_attr.instance_id,
++                   raid_attr.current_value, raid_attr.pending_value,
++                   raid_attr.read_only, raid_attr.fqdd,
++                   int(lower_bound), int(upper_bound))
++
++    def validate(self, new_value):
++        """Validates new value"""
++
++        val = int(new_value)
++        if val < self.lower_bound or val > self.upper_bound:
++            msg = ('Attribute %(attr)s cannot be set to value %(val)d.'
++                   ' It must be between %(lower)d and %(upper)d.') % {
++                       'attr': self.name,
++                       'val': new_value,
++                       'lower': self.lower_bound,
++                       'upper': self.upper_bound}
++            return msg
++
++
++class RAIDManagement(object):
++
++    NAMESPACES = [(uris.DCIM_RAIDEnumeration, RAIDEnumerableAttribute),
++                  (uris.DCIM_RAIDString, RAIDStringAttribute),
++                  (uris.DCIM_RAIDInteger, RAIDIntegerAttribute)]
++
++    def __init__(self, client):
++        """Creates RAIDManagement object
++
++        :param client: an instance of WSManClient
++        """
++        self.client = client
++
++    def list_raid_settings(self):
++        """List the RAID configuration settings
++
++        :returns: a dictionary with the RAID settings using InstanceID as the
++                  key. The attributes are either RAIDEnumerableAttribute,
++                  RAIDStringAttribute objects.
++        :raises: WSManRequestFailure on request failures
++        :raises: WSManInvalidResponse when receiving invalid response
++        :raises: DRACOperationFailed on error reported back by the DRAC
++                interface
++        """
++
++        return utils.list_settings(self.client, self.NAMESPACES,
++                                   by_name=False)
++
++    def set_raid_settings(self, raid_fqdd, new_settings):
++        """Sets the RAID configuration
++
++        It sets the pending_value parameter for each of the attributes
++        passed in. For the values to be applied, a config job must
++        be created.
++        :param raid_fqdd: the FQDD of the RAID setting.
++        :param new_settings: a dictionary containing the proposed values, with
++                         each key being the name of attribute and the value
++                         being the proposed value.
++        :returns: a dictionary containing:
++                 - The is_commit_required key with a boolean value indicating
++                   whether a config job must be created for the values to be
++                   applied.
++                 - The is_reboot_required key with a RebootRequired enumerated
++                   value indicating whether the server must be rebooted for the
++                   values to be applied. Possible values are true and false.
++        :raises: WSManRequestFailure on request failures
++        :raises: WSManInvalidResponse when receiving invalid response
++        :raises: DRACOperationFailed on error reported back by the DRAC
++                interface
++        """
++
++        return utils.set_settings('RAID',
++                                  self.client,
++                                  self.NAMESPACES,
++                                  new_settings,
++                                  uris.DCIM_RAIDService,
++                                  "DCIM_RAIDService",
++                                  "DCIM:RAIDService",
++                                  raid_fqdd,
++                                  by_name=False)
  
  
  class PhysicalDisk(PhysicalDiskTuple):
-@@ -197,7 +201,7 @@
+@@ -197,7 +474,7 @@
                                                 'PrimaryStatus')],
              firmware_version=self._get_raid_controller_attr(
                  drac_controller, 'ControllerFirmwareVersion'),
@@ -29,7 +302,7 @@
              supports_realtime=RAID_CONTROLLER_IS_REALTIME[
                  self._get_raid_controller_attr(
                      drac_controller, 'RealtimeCapability')])
-@@ -231,7 +235,12 @@
+@@ -231,7 +508,12 @@
          drac_raid_level = self._get_virtual_disk_attr(drac_disk, 'RAIDTypes')
          size_b = self._get_virtual_disk_attr(drac_disk, 'SizeInBytes')
          drac_status = self._get_virtual_disk_attr(drac_disk, 'PrimaryStatus')
@@ -43,7 +316,7 @@
          drac_pending_operations = self._get_virtual_disk_attr(
              drac_disk, 'PendingOperations')
  
-@@ -256,10 +265,12 @@
+@@ -256,10 +538,12 @@
              physical_disks=self._get_virtual_disk_attrs(drac_disk,
                                                          'PhysicalDiskIDs'))
  
@@ -58,12 +331,10 @@
  
      def _get_virtual_disk_attrs(self, drac_disk, attr_name):
          return utils.get_all_wsman_resource_attrs(
-@@ -315,7 +326,12 @@
-         drac_media_type = self._get_physical_disk_attr(drac_disk, 'MediaType',
+@@ -316,6 +600,11 @@
                                                         uri)
          drac_bus_protocol = self._get_physical_disk_attr(drac_disk,
--                                                         'BusProtocol', uri)
-+                                                         'BusProtocol', uri)
+                                                          'BusProtocol', uri)
 +        bus = self._get_physical_disk_attr(drac_disk,
 +                                           'Bus', uri,  allow_missing=True)
 +
@@ -72,7 +343,7 @@
  
          return PhysicalDisk(
              id=fqdd,
-@@ -341,7 +357,8 @@
+@@ -341,7 +630,8 @@
              device_protocol=self._get_physical_disk_attr(drac_disk,
                                                           'DeviceProtocol',
                                                           uri,
@@ -82,7 +353,7 @@
  
      def _get_physical_disk_attr(self, drac_disk, attr_name, uri,
                                  allow_missing=False):
-@@ -633,15 +650,17 @@
+@@ -633,15 +923,17 @@
          :param mode: constants.RaidStatus enumeration used to
                       determine what raid status to check for.
          :param physical_disks: all physical disks
@@ -105,7 +376,7 @@
          p_disk_id_to_status = {}
          for physical_disk in physical_disks:
              p_disk_id_to_status[physical_disk.id] = physical_disk.raid_status
-@@ -700,34 +719,37 @@
+@@ -700,34 +992,37 @@
  
              raise ValueError(error_msg)
  
@@ -114,8 +385,7 @@
      def change_physical_disk_state(self, mode,
                                     controllers_to_physical_disk_ids=None):
 -        """Convert disks RAID status and return a list of controller IDs
-+        """Convert disks RAID status
- 
+-
 -        Builds a list of controller ids that have had disks converted to the
 -        specified RAID status by:
 -        - Examining all the disks in the system and filtering out any that are
@@ -126,13 +396,14 @@
 -          statuses and raise an exception where appropriate.
 -        - Return a list of controller IDs for controllers whom have had any of
 -          their disks converted, and whether a reboot is required.
++        """Convert disks RAID status
+ 
+-        The caller typically should then create a config job for the list of
+-        controllers returned to finalize the RAID configuration.
 +        This method intelligently converts the requested physical disks from
 +        RAID to JBOD or vice versa.  It does this by only converting the
 +        disks that are not already in the correct state.
  
--        The caller typically should then create a config job for the list of
--        controllers returned to finalize the RAID configuration.
--
 -        :param mode: constants.RaidStatus enumeration used to determine what
 -                     raid status to check for.
 +        :param mode: constants.RaidStatus enumeration that indicates the mode
@@ -164,7 +435,7 @@
          :raises: DRACOperationFailed on error reported back by the DRAC and the
                   exception message does not contain NOT_SUPPORTED_MSG constant.
          :raises: Exception on unknown error.
-@@ -754,13 +776,14 @@
+@@ -754,13 +1049,14 @@
          Raise exception if there are any failed drives or
          drives not in status 'ready' or 'non-RAID'
          '''
@@ -182,7 +453,7 @@
              if physical_disk_ids:
                  LOG.debug("Converting the following disks to {} on RAID "
                            "controller {}: {}".format(
-@@ -773,22 +796,39 @@
+@@ -773,22 +1069,39 @@
                      if constants.NOT_SUPPORTED_MSG in str(ex):
                          LOG.debug("Controller {} does not support "
                                    "JBOD mode".format(controller))
@@ -234,7 +505,7 @@
                  'commit_required_ids': controllers}
  
      def is_realtime_supported(self, raid_controller_fqdd):
-@@ -805,3 +845,100 @@
+@@ -805,3 +1118,100 @@
              return True
  
          return False

--- a/src/pilot/dracclient_uris.patch
+++ b/src/pilot/dracclient_uris.patch
@@ -1,0 +1,36 @@
+--- uris.py	2018-11-26 15:48:01.000000000 -0600
++++ uris_modified.py	2020-05-06 07:58:57.209136251 -0500
+@@ -94,20 +94,29 @@
+ DCIM_PhysicalDiskView = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
+                          'DCIM_PhysicalDiskView')
+ 
++DCIM_RAIDEnumeration = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
++                        'DCIM_RAIDEnumeration')
++
++DCIM_RAIDInteger = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
++                    'DCIM_RAIDInteger')
++
+ DCIM_RAIDService = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
+                     'DCIM_RAIDService')
+ 
+-DCIM_SystemView = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
+-                   'DCIM_SystemView')
++DCIM_RAIDString = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
++                   'DCIM_RAIDString')
+ 
+ DCIM_SystemEnumeration = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
+                           'DCIM_SystemEnumeration')
+ 
++DCIM_SystemInteger = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
++                      'DCIM_SystemInteger')
++
+ DCIM_SystemString = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
+                      'DCIM_SystemString')
+ 
+-DCIM_SystemInteger = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
+-                      'DCIM_SystemInteger')
++DCIM_SystemView = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
++                   'DCIM_SystemView')
+ 
+ DCIM_VirtualDiskView = ('http://schemas.dell.com/wbem/wscim/1/cim-schema/2/'
+                         'DCIM_VirtualDiskView')

--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -287,6 +287,14 @@ apply_patch "sudo patch -b -s /usr/lib/python2.7/site-packages/dracclient/resour
 sudo rm -f /usr/lib/python2.7/site-packages/dracclient/resources/raid.pyc
 sudo rm -f /usr/lib/python2.7/site-packages/dracclient/resources/raid.pyo
 
+# This hacks in a patch to add Schema definitions and resource URIs for the classes implemented by the DRAC WS-Man API..
+echo
+echo "## Patching Ironic iDRAC driver uris.py..."
+apply_patch "sudo patch -b -s /usr/lib/python2.7/site-packages/dracclient/resources/uris.py ${HOME}/pilot/dracclient_uris.patch"
+sudo rm -f /usr/lib/python2.7/site-packages/dracclient/resources/uris.pyc
+sudo rm -f /usr/lib/python2.7/site-packages/dracclient/resources/uris.pyo
+
+
 # This hacks in a patch to allow lifecycle controller management.
 echo
 echo "## Patching Ironic iDRAC driver lifecycle_controller.py..."

--- a/src/pilot/utils.patch
+++ b/src/pilot/utils.patch
@@ -1,5 +1,5 @@
---- /usr/lib/python2.7/site-packages/dracclient/utils.py	2019-06-21 02:53:08.048945005 -0400
-+++ utils_new.py	2019-06-20 07:48:57.191489514 -0400
+--- utils.py.orig	2018-11-26 15:48:01.000000000 -0600
++++ utils_new.py	2020-05-06 08:07:47.245995658 -0500
 @@ -251,7 +251,7 @@
  
  
@@ -41,39 +41,86 @@
      items = doc.find('.//{%s}Items' % wsman.NS_WSMAN)
  
      for item in items:
-@@ -316,7 +319,8 @@
+@@ -316,7 +319,9 @@
                   cim_name,
                   target,
                   name_formatter=None,
 -                 include_commit_required=False):
 +                 include_commit_required=False,
-+                 wait_for_idrac=True):
++                 wait_for_idrac=True,
++                 by_name=True):
      """Generically handles setting various types of settings on the iDRAC
  
      This method pulls the current list of settings from the iDRAC then compares
-@@ -339,6 +343,9 @@
+@@ -339,6 +344,11 @@
                             attribute.name will be used.
      :parm include_commit_required: Indicates if the deprecated commit_required
                                     should be returned in the result.
 +    :param wait_for_idrac: indicates whether or not to wait for the
 +                           iDRAC to be ready to accept commands before issuing
 +                           the command
++    :param by_name: Controls whether returned dictionary uses RAID
++                    attribute name or instance_id as key
      :returns: a dictionary containing:
               - The commit_required key with a boolean value indicating
                 whether a config job must be created for the values to be
-@@ -361,7 +368,8 @@
+@@ -360,8 +370,9 @@
+     :raises: InvalidParameterValue on invalid new setting
      """
  
-     current_settings = list_settings(client, namespaces, by_name=True,
+-    current_settings = list_settings(client, namespaces, by_name=True,
 -                                     name_formatter=name_formatter)
++    current_settings = list_settings(client, namespaces, by_name=by_name,
 +                                     name_formatter=name_formatter,
 +                                     wait_for_idrac=wait_for_idrac)
  
      unknown_keys = set(new_settings) - set(current_settings)
      if unknown_keys:
-@@ -428,7 +436,8 @@
+@@ -376,11 +387,23 @@
+     candidates = set(new_settings)
+ 
+     for attr in candidates:
+-        if str(new_settings[attr]) == str(
+-                current_settings[attr].current_value):
+-            unchanged_attribs.append(attr)
+-        elif current_settings[attr].read_only:
++        # There are RAID settings that can have multiple values,
++        # however these are all read-only attributes.
++        # Filter out all read-only attributes first so that we exclude
++        # these settings from further consideration
++        current_setting_value = current_settings[attr].current_value
++        if type(current_setting_value) is list:
++            current_setting_value = current_setting_value[0]
++
++        unchanged_attribute = str(new_settings[attr]) == str(
++            current_setting_value)
++
++        # check if read-only attribute is unchanged
++        if current_settings[attr].read_only and not unchanged_attribute:
+             read_only_keys.append(attr)
++
++        if unchanged_attribute:
++            unchanged_attribs.append(attr)
+         else:
+             validation_msg = current_settings[attr].validate(
+                 new_settings[attr])
+@@ -425,8 +448,22 @@
+                   'AttributeName': attrib_names,
                    'AttributeValue': [new_settings[attr] for attr
                                       in attrib_names]}
++    # To set RAID settings, above we fetched list raid settings using
++    # instance_id to retrieve attribute values. When we pass instance_id in
++    # setattribute method for setting any new RAID settings, wsman raises
++    # an error. So another approach to set those settings is to list raid
++    # settings using instance_id and for settings new settings, pass the
++    # attribute names in list to SetAttributes method along with the target.
++    # That's the reason, we need to handle RAID specific settings like below
++    if settings_type == 'RAID':
++        properties['AttributeName'] = [current_settings[attr].name for
++                                       attr in attrib_names]
++    else:
++        properties['AttributeName'] = attrib_names
++    
      doc = client.invoke(resource_uri, 'SetAttributes',
 -                        selectors, properties)
 +                        selectors, properties,

--- a/src/pilot/utils.patch
+++ b/src/pilot/utils.patch
@@ -1,5 +1,5 @@
 --- utils.py.orig	2018-11-26 15:48:01.000000000 -0600
-+++ utils_new.py	2020-05-06 08:07:47.245995658 -0500
++++ utils_new.py	2020-05-07 01:30:31.943702424 -0500
 @@ -251,7 +251,7 @@
  
  
@@ -104,8 +104,11 @@
          else:
              validation_msg = current_settings[attr].validate(
                  new_settings[attr])
-@@ -425,8 +448,22 @@
-                   'AttributeName': attrib_names,
+@@ -422,11 +445,24 @@
+                  'SystemCreationClassName': 'DCIM_ComputerSystem',
+                  'SystemName': 'DCIM:ComputerSystem'}
+     properties = {'Target': target,
+-                  'AttributeName': attrib_names,
                    'AttributeValue': [new_settings[attr] for attr
                                       in attrib_names]}
 +    # To set RAID settings, above we fetched list raid settings using


### PR DESCRIPTION
Hey Chris,

I have added all the changes of two upstream patch as a monkey patch for python-dracclient below:
 
1. Add the ability to manage RAID settings : https://review.opendev.org/#/c/715172/
2. Fix for read-only and unchanged attributes:  https://review.opendev.org/#/c/722625/

I tested this monkey patches using command line but to be sure that it works, i started full deployment  on 71 stamp. Till then please do not merge this PR. 
After testing I will update and remove WIP on this PR.

Thanks and Regards,
Rachit