### PR TITLE
Remove T10PI workaround

### DIFF
--- a/src/pilot/customize_image.sh
+++ b/src/pilot/customize_image.sh
@@ -144,12 +144,7 @@ if [ ! -z "${satellite_hostname}" ]; then
         --sm-unregister \
         --selinux-relabel -v"
 else
-   run_command "virt-customize -a overcloud-full.qcow2 --run-command \"echo '${director_ip} ${director_short} ${director_long}' >> /etc/hosts\""
-
-   #Patch for configuring T10 PI format drives
-   run_command "virt-customize -a overcloud-full.qcow2  --run-command \"sed -i 's/GRUB_CMDLINE_LINUX=\\\"/GRUB_CMDLINE_LINUX=\\\"mpt3sas.prot_mask=1 /' /etc/default/grub\""
-   run_command "virt-customize -a overcloud-full.qcow2 --run-command \"grub2-mkconfig -o /boot/efi/EFI/redhat/grub.cfg\""
-
+    run_command "virt-customize -a overcloud-full.qcow2 --run-command \"echo '${director_ip} ${director_short} ${director_long}' >> /etc/hosts\""
 
     run_command "virt-customize \
         --memsize 2000 \


### PR DESCRIPTION
This patch removes the workaround for the T10PI issue since the
permanent fix has been released and verified in the HBA330 firmware
version 16.17.01.00.

Note that JetStream and Ironic users will need to upgrade the firmware
on their HBA330s to ensure that they do not encounter the T10PI issue
once this patch is merged.