### PR TITLE
ctlplane-subnet gateway correction

### DIFF
--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -2170,7 +2170,7 @@ class Director(InfraHost):
         uconf.set('ctlplane-subnet', 'inspection_iprange',
                   setts.discovery_ip_range)
         uconf.set('ctlplane-subnet', 'gateway',
-                  setts.provisioning_gateway)
+                  setts.director_node.provisioning_ip)
         # set enable_routed_networks create and deine routed networks
         is_enable_routed_networks = bool(setts.node_type_data_map)
 


### PR DESCRIPTION
Last edge patch incorrectly set cntlplane-subnet gateway to settings.provisioning_gateway, it should have remained settings.director_node.provisioning_ip