### PR TITLE
Reviewed performance tunings in first-boot.yaml

### DIFF
--- a/src/pilot/templates/dell-environment.yaml
+++ b/src/pilot/templates/dell-environment.yaml
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 resource_registry:
-    OS::TripleO::NodeUserData: ./first-boot.yaml
+  OS::TripleO::NodeUserData: ./first-boot.yaml
 
 parameter_defaults:
 
@@ -57,9 +57,6 @@ parameter_defaults:
   # Number of Dell Compute nodes
   DellComputeCount: 3
 
-  # Apply tuned-adm profile on Compute Nodes
-  ComputeTunedAdmProfile: virtual-host
-
   # Number of Controller nodes
   ControllerCount: 3
 
@@ -101,5 +98,7 @@ parameter_defaults:
     nova::api::max_limit: 10000
     nova::rpc_response_timeout: 180
     neutron::rpc_response_timeout: 180
+    cinder::rpc_response_timeout: 180
+    glance::rpc_response_timeout: 180
     tripleo::profile::pacemaker::database::mysql::innodb_flush_log_at_trx_commit: 0
     tripleo::haproxy::haproxy_default_maxconn: 10000

--- a/src/pilot/templates/first-boot.yaml
+++ b/src/pilot/templates/first-boot.yaml
@@ -14,21 +14,12 @@
 
 heat_template_version: rocky
 
-parameters:
-  ComputeTunedAdmProfile:
-    description: >
-      Apply tuned profile on compute nodes.
-      Example: "tuned-adm profile virtual-host"
-    type: string
-    default: "virtual-host"
-
 resources:
   userdata:
     type: OS::Heat::MultipartMime
     properties:
       parts:
       - config: {get_resource: set_os_limits}
-      - config: {get_resource: performance_optimization}
       - config: {get_resource: wipe_disk}
 
   set_os_limits:
@@ -40,32 +31,6 @@ resources:
         - sed -ie 's/[[:space:]]\+/ /g' /etc/security/limits.conf; grep -v '^#' /etc/security/limits.conf | grep -q '^* hard nofile' && sed -i 's/^* hard nofile.*/* hard nofile 64000/' /etc/security/limits.conf || echo '* hard nofile 64000' >> /etc/security/limits.conf
         - sed -ie 's/[[:space:]]\+/ /g' /etc/security/limits.d/20-nproc.conf; grep -v '^#' /etc/security/limits.d/20-nproc.conf | grep -q '^* soft nproc' && sed -i 's/^* soft nproc.*/* soft nproc 10240/' /etc/security/limits.d/20-nproc.conf || echo '* soft nproc 10240' >> /etc/security/limits.d/20-nproc.conf
         - sed -ie 's/[[:space:]]\+/ /g' /etc/security/limits.d/20-nproc.conf; grep -v '^#' /etc/security/limits.d/20-nproc.conf | grep -q '^root soft nproc' && sed -i 's/^root soft nproc.*/root soft nproc unlimited/' /etc/security/limits.d/20-nproc.conf || echo 'root soft nproc unlimited' >> /etc/security/limits.d/20-nproc.conf
-
-  performance_optimization:
-    type: OS::Heat::SoftwareConfig
-    properties:
-      config:
-        str_replace:
-          template: |
-            #!/bin/bash
-            if [[ $(hostname) == *compute* ]] ; then
-              echo "Performing tuned-profile"
-              tuned-adm profile _TunedProfile_
-              echo "Applied _TunedProfile_ profile"
-            fi >> /tmp/tuned-applied.log 2>&1
-
-            if [[ $(hostname) == *controller* ]] ; then
-
-              # Openstack Service - Cinder
-              sed -i "s/transport_url    \=.*/&\n    rpc_response_timeout    => 180,/" /etc/puppet/modules/cinder/manifests/init.pp
-              # Openstack Service - Glance
-              sed -i 's/rpc_response_timeout \=.*/rpc_response_timeout = 180,/' /etc/puppet/modules/oslo/manifests/messaging/default.pp
-
-          
-            fi >> /tmp/performance_optimization.log 2>&1
-
-          params:
-            _TunedProfile_: {get_param: ComputeTunedAdmProfile}
 
   wipe_disk:
     type: OS::Heat::SoftwareConfig


### PR DESCRIPTION
- rpc_response_timeout paramater is now used instead of sed commands in first-boot.yaml

- tuned profile is automatically applied by 'Tuned' service of Openstack and default "virtual-host" is defined in roles-data.yaml
