### PR TITLE
DPDK support for Rhosp 16.1, Heat/Nic Templates

### DIFF
--- a/src/pilot/templates/neutron-ovs-dpdk.yaml
+++ b/src/pilot/templates/neutron-ovs-dpdk.yaml
@@ -22,7 +22,7 @@ parameter_defaults:
   NeutronVhostuserSocketDir: "/var/lib/vhost_sockets"
 # DELL-NFV Overrides
   NovaSchedulerDefaultFilters: "ComputeFilter,AvailabilityZoneFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,NUMATopologyFilter"
-  OvsDpdkDriverType: "mlx5_core"
+  OvsDpdkDriverType: "mlx5_core" 
   NeutronPluginExtensions: "qos,port_security"
   NeutronOVSFirewallDriver: openvswitch
   DellComputeParameters:
@@ -35,9 +35,9 @@ parameter_defaults:
     NovaReservedHostMemory: 4096
     OvsDpdkSocketMemory: "2048,2048"
     TunedProfileName: "cpu-partitioning"
-    NumDpdkInterfaceRxQueues: 1
-    OvsEnableDpdk: true
- DellComputeHCIParameters:
+    NovaLibvirtRxQueueSize: 1024
+    NovaLibvirtTxQueueSize: 1024
+  DellComputeHCIParameters:
     VhostuserSocketGroup: "hugetlbfs"
     OvsPmdCoreList: "4-7,28-31"
     OvsDpdkCoreList: "0-3,24-27"
@@ -47,5 +47,6 @@ parameter_defaults:
     NovaReservedHostMemory: 4096
     OvsDpdkSocketMemory: "2048,2048"
     TunedProfileName: "cpu-partitioning"
-    NumDpdkInterfaceRxQueues: 1
-    OvsEnableDpdk: true
+    NovaLibvirtRxQueueSize: 1024
+    NovaLibvirtTxQueueSize: 1024
+

--- a/src/pilot/templates/nic-configs/ovs-dpdk_6_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_6_port/controller.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for controller nodes.
+  Bond and VLAN configuration for controller nodes. comment14_0: ' The values of the following parameters are overridden by
+  the entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -104,35 +154,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -152,7 +208,7 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                    get_param: ProvisioningMtu
                 use_dhcp: false
                 addresses:
                 - ip_netmask:
@@ -183,7 +239,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -191,19 +247,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -212,7 +268,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -221,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -231,32 +287,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_6_port/dellcompute_dpdk.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_6_port/dellcompute_dpdk.yaml
@@ -50,15 +50,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -109,35 +142,45 @@ parameters:
     default: mlx5_core
     description: DPDK driver for Mellanox
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  NumDpdkInterfaceRxQueues:
+    description: Number of Rx Queues required for DPDK bond or DPDK ports
+    default: 1
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -159,7 +202,7 @@ resources:
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -181,19 +224,19 @@ resources:
                   name:
                     get_param: ComputeBond0Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond0
                 vlan_id:
                   get_param: TenantNetworkVlanID
                 mtu:
-                  get_param: TenantNetworkMTU
+                  get_param: TenantMtu
                 addresses:
                 - ip_netmask:
                     get_param: TenantIpSubnet
@@ -202,67 +245,69 @@ resources:
                 vlan_id:
                   get_param: InternalApiNetworkVlanID
                 mtu:
-                  get_param: InternalApiMTU
+                  get_param: InternalApiMtu
                 addresses:
                 - ip_netmask:
                     get_param: InternalApiIpSubnet
               - type: ovs_user_bridge
                 name: br-tenant
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: DefaultBondMtu
                 use_dhcp: false
                 members:
                 - type: ovs_dpdk_bond
-                  name: ovs_dpdk_bond10
+                  name: dpdkbond0
+                  rx_queue:
+                    get_param: NumDpdkInterfaceRxQueues
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   ovs_options:
                     get_param: BondInterfaceOvsOptions
                   members:
                   - type: ovs_dpdk_port
                     name: dpdk0
+                    mtu:
+                        get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface1
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk1
+                    mtu:
+                        get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface2
-                      mtu:
-                        get_param: DefaultBondMTU
               - type: linux_bond
                 name: bond1
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond1
                 vlan_id:
                   get_param: StorageNetworkVlanID
                 mtu:
-                  get_param: StorageNetworkMTU
+                  get_param: StorageMtu
                 addresses:
                 - ip_netmask:
                     get_param: StorageIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_6_port/nic_environment.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_6_port/nic_environment.yaml
@@ -19,44 +19,37 @@ resource_registry:
 
 
 parameter_defaults:
-  # CHANGEME: Change the interface names in the following lines for the
-  # controller nodes provisioning interface and to include in the controller
-  # nodes bonds
-  #ControllerProvisioningInterface: em3
-  ControllerBond0Interface1: em1
-  ControllerBond0Interface2: p3p1
-  ControllerBond1Interface1: em2
-  ControllerBond1Interface2: p3p2
+  # CHANGEME: Change the interface names in the following lines
+  # to include in the controller nodes bonds
+  ControllerBond0Interface1: ens5f0
+  ControllerBond0Interface2: ens7f0
+  ControllerBond1Interface1: ens5f1
+  ControllerBond1Interface2: ens7f1
   # The bonding mode to use for controller nodes
   ControllerBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
-  # CHANGEME: Change the interface names in the following lines for the
-  # compute nodes provisioning interface and to include in the compute
-  # nodes bonds
-  #ComputeProvisioningInterface: em3
-  ComputeBond0Interface1: em1
-  ComputeBond0Interface2: p3p1
-  ComputeBond1Interface1: em2
-  ComputeBond1Interface2: p3p2
+  # CHANGEME: Change the interface names in the following lines
+  # to include in the compute nodes bonds
+  ComputeBond0Interface1: ens5f0
+  ComputeBond0Interface2: ens3f0
+  ComputeBond1Interface1: ens5f1
+  ComputeBond1Interface2: ens3f1
   # The bonding mode to use for compute nodes
   ComputeBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
-  # CHANGEME: Change the interface names in the following lines for the
-  # compute nodes provisioning interface and to include in the compute
-  # DPDK bonds
-  ComputeOvsDpdkInterface1: p2p1
-  ComputeOvsDpdkInterface2: p3p1
+  # CHANGEME: Change the interface names in the following lines 
+  # for the compute DPDK bonds
+  ComputeOvsDpdkInterface1: ens4f0
+  ComputeOvsDpdkInterface2: ens4f1
   # The DPDK bonding mode to use for compute nodes
   BondInterfaceOvsOptions: bond_mode=balance-tcp lacp=active
   HostNicDriver: mlx5_core
   
-  # CHANGEME: Change the interface names in the following lines for the
-  # storage nodes provisioning interface and to include in the storage
-  # nodes bonds
-  #StorageProvisioningInterface: em3
-  StorageBond0Interface1: em1
-  StorageBond0Interface2: p2p1
-  StorageBond1Interface1: em2
-  StorageBond1Interface2: p2p2
+  # CHANGEME: Change the interface names in the following lines
+  # to include in the storage nodes bonds
+  StorageBond0Interface1: ens1f0
+  StorageBond0Interface2: ens2f0
+  StorageBond1Interface1: ens1f1
+  StorageBond1Interface2: ens2f1
   # The bonding mode to use for storage nodes
   StorageBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1

--- a/src/pilot/templates/nic-configs/ovs-dpdk_6_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_6_port/storage.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for storage nodes.
+  Bond and VLAN configuration for storage nodes. comment14_0: ' The values of the following parameters are overridden by the
+  entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,15 +55,40 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -96,31 +122,37 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -139,11 +171,11 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-bond0
-                mtu:
-                  get_param: ProvisioningNetworkMTU
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
+                mtu:
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -161,7 +193,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -169,51 +201,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_7_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_7_port/controller.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for controller nodes.
+  Bond and VLAN configuration for controller nodes. comment14_0: ' The values of the following parameters are overridden by
+  the entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -108,35 +158,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -156,9 +212,9 @@ resources:
               - type: interface
                 name:
                   get_param: ControllerProvisioningInterface
-                mtu:
-                  get_param: ProvisioningNetworkMTU
                 use_dhcp: false
+                mtu:
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -187,12 +243,12 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -200,19 +256,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -221,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -230,7 +286,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -240,32 +296,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_7_port/dellcompute_dpdk.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_7_port/dellcompute_dpdk.yaml
@@ -50,15 +50,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -113,35 +146,45 @@ parameters:
     default: mlx5_core
     description: DPDK driver for Mellanox
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  NumDpdkInterfaceRxQueues:
+    description: Number of Rx Queues required for DPDK bond or DPDK ports
+    default: 1
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -162,7 +205,7 @@ resources:
                 name:
                   get_param: ComputeProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -184,25 +227,25 @@ resources:
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond0
                 vlan_id:
                   get_param: TenantNetworkVlanID
                 mtu:
-                  get_param: TenantNetworkMTU
+                  get_param: TenantMtu
                 addresses:
                 - ip_netmask:
                     get_param: TenantIpSubnet
@@ -211,67 +254,69 @@ resources:
                 vlan_id:
                   get_param: InternalApiNetworkVlanID
                 mtu:
-                  get_param: InternalApiMTU
+                  get_param: InternalApiMtu
                 addresses:
                 - ip_netmask:
                     get_param: InternalApiIpSubnet
               - type: ovs_user_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 use_dhcp: false
                 members:
                 - type: ovs_dpdk_bond
-                  name: ovs_dpdk_bond10
+                  name: dpdkbond0
+                  rx_queue:
+                    get_param: NumDpdkInterfaceRxQueues
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   ovs_options:
                     get_param: BondInterfaceOvsOptions
                   members:
                   - type: ovs_dpdk_port
                     name: dpdk0
+                    mtu:
+                      get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface1
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk1
+                    mtu:
+                      get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface2
-                      mtu:
-                        get_param: DefaultBondMTU
               - type: linux_bond
                 name: bond1
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond1
                 vlan_id:
                   get_param: StorageNetworkVlanID
                 mtu:
-                  get_param: StorageNetworkMTU
+                  get_param: StorageMtu
                 addresses:
                 - ip_netmask:
                     get_param: StorageIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_7_port/nic_environment.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_7_port/nic_environment.yaml
@@ -22,30 +22,30 @@ parameter_defaults:
   # CHANGEME: Change the interface names in the following lines for the
   # controller nodes provisioning interface and to include in the controller
   # nodes bonds
-  ControllerProvisioningInterface: em3
-  ControllerBond0Interface1: em1
-  ControllerBond0Interface2: p3p1
-  ControllerBond1Interface1: em2
-  ControllerBond1Interface2: p3p2
+  ControllerProvisioningInterface: eno3
+  ControllerBond0Interface1: ens5f0
+  ControllerBond0Interface2: ens7f0
+  ControllerBond1Interface1: ens5f1
+  ControllerBond1Interface2: ens7f1
   # The bonding mode to use for controller nodes
   ControllerBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
   # CHANGEME: Change the interface names in the following lines for the
   # compute nodes provisioning interface and to include in the compute
   # nodes bonds
-  ComputeProvisioningInterface: em3
-  ComputeBond0Interface1: em1
-  ComputeBond0Interface2: p3p1
-  ComputeBond1Interface1: em2
-  ComputeBond1Interface2: p3p2
+  ComputeProvisioningInterface: eno3
+  ComputeBond0Interface1: ens5f0
+  ComputeBond0Interface2: ens3f0
+  ComputeBond1Interface1: ens5f1
+  ComputeBond1Interface2: ens3f1
   # The bonding mode to use for compute nodes
   ComputeBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
   # CHANGEME: Change the interface names in the following lines for the
   # compute nodes provisioning interface and to include in the compute
   # DPDK bonds
-  ComputeOvsDpdkInterface1: p2p1
-  ComputeOvsDpdkInterface2: p3p1
+  ComputeOvsDpdkInterface1: ens4f0
+  ComputeOvsDpdkInterface2: ens4f1
   # The DPDK bonding mode to use for compute nodes
   BondInterfaceOvsOptions: bond_mode=balance-tcp lacp=active
   HostNicDriver: mlx5_core
@@ -53,10 +53,10 @@ parameter_defaults:
   # CHANGEME: Change the interface names in the following lines for the
   # storage nodes provisioning interface and to include in the storage
   # nodes bonds
-  StorageProvisioningInterface: em3
-  StorageBond0Interface1: em1
-  StorageBond0Interface2: p2p1
-  StorageBond1Interface1: em2
-  StorageBond1Interface2: p2p2
+  StorageProvisioningInterface: eno3
+  StorageBond0Interface1: ens1f0
+  StorageBond0Interface2: ens2f0
+  StorageBond1Interface1: ens1f1
+  StorageBond1Interface2: ens2f1
   # The bonding mode to use for storage nodes
   StorageBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1

--- a/src/pilot/templates/nic-configs/ovs-dpdk_7_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_7_port/storage.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for storage nodes.
+  Bond and VLAN configuration for storage nodes. comment14_0: ' The values of the following parameters are overridden by the
+  entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,15 +55,45 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneNetCidr:
+    description: Control plane/provisioning network and mask
+    type: string
+    default: ''
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
+    default: ''
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -100,31 +131,37 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -145,7 +182,7 @@ resources:
                 name:
                   get_param: StorageProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -165,12 +202,12 @@ resources:
               - type: ovs_bridge
                 name: br-bond0
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -178,51 +215,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_8_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_8_port/controller.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for controller nodes.
+  Bond and VLAN configuration for controller nodes. comment14_0: ' The values of the following parameters are overridden by
+  the entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -104,35 +154,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -151,9 +207,9 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-tenant
-                use_dhcp: false
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                    get_param: ProvisioningMtu
+                use_dhcp: false
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -183,7 +239,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -191,19 +247,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -212,7 +268,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -221,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -231,32 +287,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_8_port/dellcompute_dpdk.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_8_port/dellcompute_dpdk.yaml
@@ -50,15 +50,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -117,35 +150,45 @@ parameters:
     default: mlx5_core
     description: DPDK driver for Mellanox
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  NumDpdkInterfaceRxQueues:
+    description: Number of Rx Queues required for DPDK bond or DPDK ports
+    default: 1
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -167,7 +210,7 @@ resources:
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -189,19 +232,19 @@ resources:
                   name:
                     get_param: ComputeBond0Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond0
                 vlan_id:
                   get_param: TenantNetworkVlanID
                 mtu:
-                  get_param: TenantNetworkMTU
+                  get_param: TenantMtu
                 addresses:
                 - ip_netmask:
                     get_param: TenantIpSubnet
@@ -210,87 +253,89 @@ resources:
                 vlan_id:
                   get_param: InternalApiNetworkVlanID
                 mtu:
-                  get_param: InternalApiMTU
+                  get_param: InternalApiMtu
                 addresses:
                 - ip_netmask:
                     get_param: InternalApiIpSubnet
               - type: ovs_user_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 use_dhcp: false
                 members:
                 - type: ovs_dpdk_bond
-                  name: ovs_dpdk_bond10
+                  name: dpdkbond0
+                  rx_queue:
+                    get_param: NumDpdkInterfaceRxQueues
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   ovs_options:
                     get_param: BondInterfaceOvsOptions
                   members:
                   - type: ovs_dpdk_port
                     name: dpdk0
+                    mtu:
+                        get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface1
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk1
+                    mtu:
+                        get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface2
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk2
+                    mtu:
+                        get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface3
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk3
+                    mtu:
+                        get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface4
-                      mtu:
-                        get_param: DefaultBondMTU
               - type: linux_bond
                 name: bond1
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond1
                 vlan_id:
                   get_param: StorageNetworkVlanID
                 mtu:
-                  get_param: StorageNetworkMTU
+                  get_param: StorageMtu
                 addresses:
                 - ip_netmask:
                     get_param: StorageIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_8_port/nic_environment.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_8_port/nic_environment.yaml
@@ -19,46 +19,39 @@ resource_registry:
 
 
 parameter_defaults:
-  # CHANGEME: Change the interface names in the following lines for the
-  # controller nodes provisioning interface and to include in the controller
-  # nodes bonds
-  #ControllerProvisioningInterface: em3
-  ControllerBond0Interface1: em1
-  ControllerBond0Interface2: p3p1
-  ControllerBond1Interface1: em2
-  ControllerBond1Interface2: p3p2
+  # CHANGEME: Change the interface names in the following lines
+  # to include in the controller nodes bonds
+  ControllerBond0Interface1: ens5f0
+  ControllerBond0Interface2: ens7f0
+  ControllerBond1Interface1: ens5f1
+  ControllerBond1Interface2: ens7f1
   # The bonding mode to use for controller nodes
   ControllerBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
-  # CHANGEME: Change the interface names in the following lines for the
-  # compute nodes provisioning interface and to include in the compute
-  # nodes bonds
-  #ComputeProvisioningInterface: em3
-  ComputeBond0Interface1: em1
-  ComputeBond0Interface2: p3p1
-  ComputeBond1Interface1: em2
-  ComputeBond1Interface2: p3p2
+  # CHANGEME: Change the interface names in the following lines
+  # to include in the compute nodes bonds
+  ComputeBond0Interface1: ens5f0
+  ComputeBond0Interface2: ens3f0
+  ComputeBond1Interface1: ens5f1
+  ComputeBond1Interface2: ens3f1
   # The bonding mode to use for compute nodes
   ComputeBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
-  # CHANGEME: Change the interface names in the following lines for the
-  # compute nodes provisioning interface and to include in the compute
-  # DPDK bonds
-  ComputeOvsDpdkInterface1: p2p1
-  ComputeOvsDpdkInterface2: p3p1
-  ComputeOvsDpdkInterface3: p2p2
-  ComputeOvsDpdkInterface4: p3p2
+  # CHANGEME: Change the interface names in the following lines 
+  # for the compute DPDK bonds
+  ComputeOvsDpdkInterface1: ens4f0
+  ComputeOvsDpdkInterface2: ens8f0
+  ComputeOvsDpdkInterface3: ens4f1
+  ComputeOvsDpdkInterface4: ens8f1
   # The DPDK bonding mode to use for compute nodes
   BondInterfaceOvsOptions: bond_mode=balance-tcp lacp=active
   HostNicDriver: mlx5_core
   
-  # CHANGEME: Change the interface names in the following lines for the
-  # storage nodes provisioning interface and to include in the storage
-  # nodes bonds
-  #StorageProvisioningInterface: em3
-  StorageBond0Interface1: em1
-  StorageBond0Interface2: p2p1
-  StorageBond1Interface1: em2
-  StorageBond1Interface2: p2p2
+  # CHANGEME: Change the interface names in the following lines
+  # to include in the storage nodes bonds
+  StorageBond0Interface1: ens1f0
+  StorageBond0Interface2: ens2f0
+  StorageBond1Interface1: ens1f1
+  StorageBond1Interface2: ens2f1
   # The bonding mode to use for storage nodes
   StorageBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1

--- a/src/pilot/templates/nic-configs/ovs-dpdk_8_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_8_port/storage.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for storage nodes.
+  Bond and VLAN configuration for storage nodes. comment14_0: ' The values of the following parameters are overridden by the
+  entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,15 +55,40 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -96,31 +122,37 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -139,11 +171,11 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-bond0
-                mtu:
-                  get_param: ProvisioningNetworkMTU
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
+                mtu:
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -161,7 +193,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -169,51 +201,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_9_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_9_port/controller.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for controller nodes.
+  Bond and VLAN configuration for controller nodes. comment14_0: ' The values of the following parameters are overridden by
+  the entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -108,35 +158,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -158,7 +214,7 @@ resources:
                   get_param: ControllerProvisioningInterface
                 use_dhcp: false
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -187,12 +243,12 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -200,19 +256,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -221,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -230,7 +286,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -240,32 +296,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_9_port/dellcompute_dpdk.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_9_port/dellcompute_dpdk.yaml
@@ -50,15 +50,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -121,35 +154,45 @@ parameters:
     default: mlx5_core
     description: DPDK driver for Mellanox
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  NumDpdkInterfaceRxQueues:
+    description: Number of Rx Queues required for DPDK bond or DPDK ports
+    default: 1
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -170,7 +213,7 @@ resources:
                 name:
                   get_param: ComputeProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -192,25 +235,25 @@ resources:
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond0
                 vlan_id:
                   get_param: TenantNetworkVlanID
                 mtu:
-                  get_param: TenantNetworkMTU
+                  get_param: TenantMtu
                 addresses:
                 - ip_netmask:
                     get_param: TenantIpSubnet
@@ -219,87 +262,89 @@ resources:
                 vlan_id:
                   get_param: InternalApiNetworkVlanID
                 mtu:
-                  get_param: InternalApiMTU
+                  get_param: InternalApiMtu
                 addresses:
                 - ip_netmask:
                     get_param: InternalApiIpSubnet
               - type: ovs_user_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 use_dhcp: false
                 members:
                 - type: ovs_dpdk_bond
-                  name: ovs_dpdk_bond10
+                  name: dpdkbond0
+                  rx_queue:
+                    get_param: NumDpdkInterfaceRxQueues
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   ovs_options:
                     get_param: BondInterfaceOvsOptions
                   members:
                   - type: ovs_dpdk_port
                     name: dpdk0
+                    mtu:
+                      get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface1
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk1
+                    mtu:
+                      get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface2
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk2
+                    mtu:
+                      get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface3
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk3
+                    mtu:
+                      get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface4
-                      mtu:
-                        get_param: DefaultBondMTU
               - type: linux_bond
                 name: bond1
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond1
                 vlan_id:
                   get_param: StorageNetworkVlanID
                 mtu:
-                  get_param: StorageNetworkMTU
+                  get_param: StorageMtu
                 addresses:
                 - ip_netmask:
                     get_param: StorageIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_9_port/nic_environment.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_9_port/nic_environment.yaml
@@ -22,32 +22,32 @@ parameter_defaults:
   # CHANGEME: Change the interface names in the following lines for the
   # controller nodes provisioning interface and to include in the controller
   # nodes bonds
-  ControllerProvisioningInterface: em3
-  ControllerBond0Interface1: em1
-  ControllerBond0Interface2: p3p1
-  ControllerBond1Interface1: em2
-  ControllerBond1Interface2: p3p2
+  ControllerProvisioningInterface: eno3
+  ControllerBond0Interface1: ens5f0
+  ControllerBond0Interface2: ens7f0
+  ControllerBond1Interface1: ens5f1
+  ControllerBond1Interface2: ens7f1
   # The bonding mode to use for controller nodes
   ControllerBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
   # CHANGEME: Change the interface names in the following lines for the
   # compute nodes provisioning interface and to include in the compute
   # nodes bonds
-  ComputeProvisioningInterface: em3
-  ComputeBond0Interface1: em1
-  ComputeBond0Interface2: p3p1
-  ComputeBond1Interface1: em2
-  ComputeBond1Interface2: p3p2
+  ComputeProvisioningInterface: eno3
+  ComputeBond0Interface1: ens5f0
+  ComputeBond0Interface2: ens3f0
+  ComputeBond1Interface1: ens5f1
+  ComputeBond1Interface2: ens3f1
   # The bonding mode to use for compute nodes
   ComputeBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
   # CHANGEME: Change the interface names in the following lines for the
   # compute nodes provisioning interface and to include in the compute
   # DPDK bonds
-  ComputeOvsDpdkInterface1: p2p1
-  ComputeOvsDpdkInterface2: p3p1
-  ComputeOvsDpdkInterface3: p2p2
-  ComputeOvsDpdkInterface4: p3p2
+  ComputeOvsDpdkInterface1: ens4f0
+  ComputeOvsDpdkInterface2: ens8f0
+  ComputeOvsDpdkInterface3: ens4f1
+  ComputeOvsDpdkInterface4: ens8f1
   # The DPDK bonding mode to use for compute nodes
   BondInterfaceOvsOptions: bond_mode=balance-tcp lacp=active
   HostNicDriver: mlx5_core
@@ -55,10 +55,10 @@ parameter_defaults:
   # CHANGEME: Change the interface names in the following lines for the
   # storage nodes provisioning interface and to include in the storage
   # nodes bonds
-  StorageProvisioningInterface: em3
-  StorageBond0Interface1: em1
-  StorageBond0Interface2: p2p1
-  StorageBond1Interface1: em2
-  StorageBond1Interface2: p2p2
+  StorageProvisioningInterface: eno3
+  StorageBond0Interface1: ens1f0
+  StorageBond0Interface2: ens2f0
+  StorageBond1Interface1: ens1f1
+  StorageBond1Interface2: ens2f1
   # The bonding mode to use for storage nodes
   StorageBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1

--- a/src/pilot/templates/nic-configs/ovs-dpdk_9_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_9_port/storage.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for storage nodes.
+  Bond and VLAN configuration for storage nodes. comment14_0: ' The values of the following parameters are overridden by the
+  entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,15 +55,45 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneNetCidr:
+    description: Control plane/provisioning network and mask
+    type: string
+    default: ''
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
+    default: ''
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -100,31 +131,37 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -145,7 +182,7 @@ resources:
                 name:
                   get_param: StorageProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -165,12 +202,12 @@ resources:
               - type: ovs_bridge
                 name: br-bond0
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -178,51 +215,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet


### PR DESCRIPTION
- Heat Network Templates for OVS-DPDK deployment with RHOSP16.1

- Fixed typos and updated parameters for deployment