### PR TITLE
Unity and Powermax Fixes for 16.1

### DIFF
--- a/src/deploy/osp_deployer/settings/config.py
+++ b/src/deploy/osp_deployer/settings/config.py
@@ -624,8 +624,12 @@ class Settings:
             '/pilot/templates/dellsc-cinder-config.yaml'
         self.dell_unity_cinder_yaml = self.foreman_configuration_scripts + \
             '/pilot/templates/dellemc-unity-cinder-backend.yaml'
+        self.dell_unity_cinder_container_yaml = self.foreman_configuration_scripts + \
+            '/pilot/templates/dellemc-unity-cinder-container.yaml'
         self.unity_manila_yaml = self.foreman_configuration_scripts + \
             '/pilot/templates/unity-manila-config.yaml'
+        self.unity_manila_container_yaml = self.foreman_configuration_scripts + \
+            '/pilot/templates/unity-manila-container.yaml'
         self.dell_powermax_iscsi_cinder_yaml = self.foreman_configuration_scripts + \
             '/pilot/templates/dellemc-powermax-iscsi-cinder-backend.yaml'
         self.dell_powermax_fc_cinder_yaml = self.foreman_configuration_scripts + \

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -472,9 +472,9 @@ dellsc_multipath_xref=true
 enable_unity_backend=false
 # The Dell EMC Unity Container is published in the RH Container Catalog
 # registry.connect.redhat.com
-# By default, the latest image of the RHOSP release is pulled.
+# By default, this version of the image of the RHOSP release is pulled.
 # Change to a different version if a specific image is required.
-cinder_unity_container_version=latest
+cinder_unity_container_version=16.1-1
 unity_backend_name=CHANGEME
 unity_san_ip=CHANGEME
 unity_san_login=CHANGEME
@@ -490,9 +490,9 @@ unity_storage_pool_names=CHANGEME
 enable_unity_manila_backend=false
 # The Dell EMC Unity Container is published in the RH Container Catalog
 # registry.connect.redhat.com
-# By default, the latest image of the RHOSP release is pulled.
+# By default, this version of the image of the RHOSP release is pulled.
 # Change to a different version if a specific image is required.
-manila_unity_container_version=latest
+manila_unity_container_version=16.1-1
 manila_unity_driver_handles_share_servers=true
 manila_unity_nas_login=CHANGEME
 manila_unity_nas_password=CHANGEME

--- a/src/deploy/osp_deployer/settings/sample_hci_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_hci_profile.ini
@@ -472,9 +472,9 @@ dellsc_multipath_xref=true
 enable_unity_backend=false
 # The Dell EMC Unity Container is published in the RH Container Catalog
 # registry.connect.redhat.com
-# By default, the latest image of the RHOSP release is pulled.
+# By default, this version of the image of the RHOSP release is pulled.
 # Change to a different version if a specific image is required.
-cinder_unity_container_version=latest
+cinder_unity_container_version=16.1-1
 unity_backend_name=CHANGEME
 unity_san_ip=CHANGEME
 unity_san_login=CHANGEME
@@ -489,9 +489,9 @@ unity_storage_pool_names=CHANGEME
 enable_unity_manila_backend=false
 # The Dell EMC Unity Container is published in the RH Container Catalog
 # registry.connect.redhat.com
-# By default, the latest image of the RHOSP release is pulled.
+# By default, this version of the image of the RHOSP release is pulled.
 # Change to a different version if a specific image is required.
-manila_unity_container_version=latest
+manila_unity_container_version=16.1-1
 manila_unity_driver_handles_share_servers=true
 manila_unity_nas_login=CHANGEME
 manila_unity_nas_password=CHANGEME

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -470,9 +470,9 @@ dellsc_multipath_xref=true
 enable_unity_backend=false
 # The Dell EMC Unity Container is published in the RH Container Catalog
 # registry.connect.redhat.com
-# By default, the latest image of the RHOSP release is pulled.
+# By default, this version of the image of the RHOSP release is pulled.
 # Change to a different version if a specific image is required.
-cinder_unity_container_version=latest
+cinder_unity_container_version=16.1-1
 unity_backend_name=CHANGEME
 unity_san_ip=CHANGEME
 unity_san_login=CHANGEME
@@ -488,9 +488,9 @@ unity_storage_pool_names=CHANGEME
 enable_unity_manila_backend=false
 # The Dell EMC Unity Container is published in the RH Container Catalog
 # registry.connect.redhat.com
-# By default, the latest image of the RHOSP release is pulled.
+# By default, this version of the image of the RHOSP release is pulled.
 # Change to a different version if a specific image is required.
-manila_unity_container_version=latest
+manila_unity_container_version=16.1-1
 manila_unity_driver_handles_share_servers=true
 manila_unity_nas_login=CHANGEME
 manila_unity_nas_password=CHANGEME

--- a/src/pilot/deploy-overcloud.py
+++ b/src/pilot/deploy-overcloud.py
@@ -577,8 +577,12 @@ def main():
 
         if args.enable_unity:
             env_opts += " -e ~/pilot/templates/dellemc-unity-cinder-" \
+                        "container.yaml"
+            env_opts += " -e ~/pilot/templates/dellemc-unity-cinder-" \
                         "backend.yaml"
+
         if args.enable_unity_manila:
+            env_opts += " -e ~/pilot/templates/unity-manila-container.yaml"
             env_opts += " -e ~/pilot/templates/unity-manila-config.yaml"
 
         if args.enable_powermax:

--- a/src/pilot/templates/dellemc-powermax-fc-cinder-backend.yaml
+++ b/src/pilot/templates/dellemc-powermax-fc-cinder-backend.yaml
@@ -10,7 +10,7 @@ parameter_defaults:
         tripleo_dellemc_powermax/san_login:
             value: <powermax_san_login>
         tripleo_dellemc_powermax/san_password:
-            value: <tripleo_dellemc_powermax_san_password>
+            value: <powermax_san_password>
         tripleo_dellemc_powermax/vmax_port_groups:
             value: '<powermax_port_groups>'
         tripleo_dellemc_powermax/vmax_array:

--- a/src/pilot/templates/dellemc-powermax-iscsi-cinder-backend.yaml
+++ b/src/pilot/templates/dellemc-powermax-iscsi-cinder-backend.yaml
@@ -1,5 +1,5 @@
 parameter_defaults: 
-  CinderEnableIscsiBackend:true
+  CinderEnableIscsiBackend: false
 
 parameter_defaults:
   ControllerExtraConfig:

--- a/src/pilot/templates/dellemc-unity-cinder-backend.yaml
+++ b/src/pilot/templates/dellemc-unity-cinder-backend.yaml
@@ -6,9 +6,9 @@ resource_registry:
 parameter_defaults:
   CinderEnableDellEMCUnityBackend: true
   CinderDellEMCUnityBackendName: 'tripleo_dellemc_unity'
-  CinderDellEMCUnitySanIp: <unity_san_ip>
-  CinderDellEMCUnitySanLogin: <unity_san_login>
-  CinderDellEMCUnitySanPassword: <unity_san_password>
-  CinderDellEMCUnityStorageProtocol: <unity_storage_protocol>
-  CinderDellEMCUnityIoPorts: <unity_io_ports>
-  CinderDellEMCUnityStoragePoolNames: <unity_storage_pool_names>
+  CinderDellEMCUnitySanIp: '<unity_san_ip>'
+  CinderDellEMCUnitySanLogin: '<unity_san_login>'
+  CinderDellEMCUnitySanPassword: '<unity_san_password>'
+  CinderDellEMCUnityStorageProtocol: '<unity_storage_protocol>'
+  CinderDellEMCUnityIoPorts: '<unity_io_ports>'
+  CinderDellEMCUnityStoragePoolNames: '<unity_storage_pool_names>'

--- a/src/pilot/templates/dellemc-unity-cinder-container.yaml
+++ b/src/pilot/templates/dellemc-unity-cinder-container.yaml
@@ -1,0 +1,2 @@
+parameter_defaults:
+  ContainerCinderVolumeImage: <dellemc_container_registry_domain>/dellemc/openstack-cinder-volume-dellemc-rhosp16:16.1-1

--- a/src/pilot/templates/unity-manila-config.yaml
+++ b/src/pilot/templates/unity-manila-config.yaml
@@ -10,11 +10,11 @@ parameter_defaults:
   ManilaUnityBackendName: tripleo_manila_unity
 # DELL-NFV Overrides
   ManilaUnityDriverHandlesShareServers: <manila_unity_driver_handles_share_servers>
-  ManilaUnityNasLogin: <manila_unity_nas_login>
-  ManilaUnityNasPassword: <manila_unity_nas_password>
-  ManilaUnityNasServer: <manila_unity_nas_server>
-  ManilaUnityServerMetaPool: <manila_unity_server_meta_pool>
-  ManilaUnityShareDataPools: <manila_unity_share_data_pools>
-  ManilaUnityEthernetPorts: <manila_unity_ethernet_ports>
+  ManilaUnityNasLogin: '<manila_unity_nas_login>'
+  ManilaUnityNasPassword: '<manila_unity_nas_password>'
+  ManilaUnityNasServer: '<manila_unity_nas_server>'
+  ManilaUnityServerMetaPool: '<manila_unity_server_meta_pool>'
+  ManilaUnityShareDataPools: '<manila_unity_share_data_pools>'
+  ManilaUnityEthernetPorts: '<manila_unity_ethernet_ports>'
   ManilaUnityEmcSslCertVerify: <manila_unity_ssl_cert_verify>
-  ManilaUnityEmcSslCertPath: <manila_unity_ssl_cert_path>
+  ManilaUnityEmcSslCertPath: '<manila_unity_ssl_cert_path>'

--- a/src/pilot/templates/unity-manila-container.yaml
+++ b/src/pilot/templates/unity-manila-container.yaml
@@ -1,0 +1,2 @@
+parameter_defaults:
+  ContainerManilaShareImage: <dellemc_container_registry_domain>/dellemc/openstack-manila-share-dellemc-rhosp16:16.1-1


### PR DESCRIPTION
1.	Unity Cinder – Deployed. The driver initialized successfully. Created and attached volumes using ISCSI.
2.	Unity Manila – Deployed. The driver initialized successfully. Share creation failed due to a defect in storops library. Pending a fix in the container
3.	Powermax Cinder – Deployed. The driver initialized successfully. Create volumes. 

