### PR TITLE
Merge JS-16.1 into experimental-upstream-ironic-JS-16.1-00

### DIFF
--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -822,10 +822,6 @@ class Director(InfraHost):
 
     def setup_dell_storage(self):
 
-        # Clean the local docker registry
-        #if len(self.run_tty("sudo docker images -a -q")[0]) > 1:
-            #self.run_tty("sudo docker rmi $(sudo docker images -a -q) --force")
-
         # Re - Upload the yaml files in case we're trying to
         # leave the undercloud intact but want to redeploy with
         # a different config
@@ -851,11 +847,20 @@ class Director(InfraHost):
             "/dellemc-unity-cinder-backend.yaml"
         self.upload_file(self.settings.dell_unity_cinder_yaml,
                          dell_unity_cinder_yaml)
+
+        dell_unity_cinder_container_yaml = self.templates_dir + \
+            "/dellemc-unity-cinder-container.yaml"
+        self.upload_file(self.settings.dell_unity_cinder_container_yaml,
+                         dell_unity_cinder_container_yaml)
+
         # Backup before modifying
         self.run_tty("cp " + dell_unity_cinder_yaml +
                      " " + dell_unity_cinder_yaml + ".bak")
+        self.run_tty("cp " + dell_unity_cinder_container_yaml +
+                     " " + dell_unity_cinder_container_yaml + ".bak")
 
-        self.setup_unity_cinder(dell_unity_cinder_yaml)
+        self.setup_unity_cinder(dell_unity_cinder_yaml, \
+                                dell_unity_cinder_container_yaml )
 
         # Powermax
         dell_powermax_iscsi_cinder_yaml = self.templates_dir + \
@@ -906,11 +911,17 @@ class Director(InfraHost):
         unity_manila_yaml = self.templates_dir + "/unity-manila-config.yaml"
         self.upload_file(self.settings.unity_manila_yaml,
                          unity_manila_yaml)
+        unity_manila_container_yaml = self.templates_dir + "/unity-manila-container.yaml"
+        self.upload_file(self.settings.unity_manila_container_yaml,
+                         unity_manila_container_yaml)
+
         # Backup before modifying
         self.run_tty("cp " + unity_manila_yaml +
                      " " + unity_manila_yaml + ".bak")
+        self.run_tty("cp " + unity_manila_container_yaml +
+                     " " + unity_manila_container_yaml + ".bak")
 
-        self.setup_unity_manila(unity_manila_yaml)
+        self.setup_unity_manila(unity_manila_yaml, unity_manila_container_yaml)
 
         #  Now powermax
         powermax_manila_yaml = self.templates_dir + "/powermax-manila-config.yaml"
@@ -968,7 +979,8 @@ class Director(InfraHost):
         ]
         for cmd in cmds:
             self.run_tty(cmd)
-    def setup_unity_cinder(self, dell_unity_cinder_yaml):
+    def setup_unity_cinder(self, dell_unity_cinder_yaml, \
+                           dell_unity_cinder_container_yaml):
 
         if self.settings.enable_unity_backend is False:
             logger.debug("Not setting up unity cinder backend.")
@@ -994,44 +1006,50 @@ class Director(InfraHost):
             self.settings.unity_storage_pool_names + '|" ' +
             dell_unity_cinder_yaml,
         ]
-        if self.settings.use_satellite:
-            cinder_container = "openstack-cinder-volume-dellemc-rhosp16" + \
-                ':' + str(self.settings.cinder_unity_container_version)
-            remote_registry = self.settings.satellite_hostname + \
-                ":5000/" + self.settings.containers_prefix
-            local_url = remote_registry + cinder_container
-            cmds.append('sed -i "s|DockerCinderVolumeImage.*|' +
-                        'DockerCinderVolumeImage: ' + local_url +
-                        '|" ' + overcloud_images_file)
-        else:
 
+        if self.settings.use_satellite:
+            cinder_container = "openstack-cinder-volume-dellemc-rhosp16:" + \
+                str(self.settings.cinder_unity_container_version) 
+            remote_registry = self.settings.satellite_hostname + \
+                ":5000/" 
+            local_url = remote_registry + self.settings.containers_prefix + \
+                cinder_container
+            cmds.append('sed -i "s|ContainerCinderVolumeImage.*|' +
+                        'ContainerCinderVolumeImage: ' + local_url +
+                        '|" ' + dell_unity_cinder_container_yaml)
+            cmds.append('sed -i "s|<dellemc_container_registry>|' + remote_registry +
+                        '|" ' + dell_unity_cinder_container_yaml)             
+        else:
+            undercloud_domain_name = self.settings.director_node.hostname + \
+                                 ".ctlplane.localdomain"
             cinder_container = "/dellemc/openstack-cinder-volume-dellemc-rhosp16:" + \
                 str(self.settings.cinder_unity_container_version)
             remote_registry = "registry.connect.redhat.com"
             remote_url = remote_registry + cinder_container
             local_registry = self.provisioning_ip + ":8787"
-            local_url = local_registry + cinder_container
+            local_registry_domain = undercloud_domain_name + ":8787"
+            local_url = local_registry_domain + cinder_container
 
             cmds.extend([
-                'docker login -u ' + self.settings.subscription_manager_user +
+                'sudo podman login -u ' + self.settings.subscription_manager_user +
                 ' -p ' + self.settings.subscription_manager_password +
                 ' ' + remote_registry,
-                'docker pull ' + remote_url,
-                'docker tag ' + remote_url + ' ' + local_url,
-                'docker push ' + local_url,
-                'sed -i "s|DockerCinderVolumeImage.*|' +
-                'DockerCinderVolumeImage: ' + local_url +
-                '|" ' + overcloud_images_file,
-                'echo "  DockerInsecureRegistryAddress:" >> ' +
-                overcloud_images_file,
-                'sudo echo "  - ' + local_registry + ' " >> ' +
-                overcloud_images_file,
-                'docker logout ' + remote_registry,
+                'sudo podman pull ' + remote_url,
+                'sudo openstack tripleo container image push --local ' + remote_url,
+                'sudo podman tag ' + remote_url + ' ' + local_url,
+                'sed -i "s|ContainerCinderVolumeImage.*|' +
+                'ContainerCinderVolumeImage: ' + local_url +
+                '|" ' + dell_unity_cinder_container_yaml,
+                'sed -i "s|<dellemc_container_registry>|' + local_registry +
+                '|" ' + dell_unity_cinder_container_yaml,
+                'sed -i "s|<dellemc_container_registry_domain>|' + local_registry_domain +
+                        '|" ' + dell_unity_cinder_container_yaml,
+                'sudo podman logout ' + remote_registry,
             ])
         for cmd in cmds:
             self.run_tty(cmd)
 
-    def setup_unity_manila(self, unity_manila_yaml):
+    def setup_unity_manila(self, unity_manila_yaml, unity_manila_container_yaml):
 
         if self.settings.enable_unity_manila_backend is False:
             logger.debug("Not setting up unity manila backend.")
@@ -1074,33 +1092,43 @@ class Director(InfraHost):
             manila_container = "openstack-manila-share-dellemc-rhosp16" + \
                 ':' + str(self.settings.manila_unity_container_version)
             remote_registry = self.settings.satellite_hostname + \
-                ":5000/" + self.settings.containers_prefix
-            local_url = remote_registry + manila_container
-            cmds.append('sed -i "50i \  DockerManilaShareImage: ' + local_url +
-                        '" ' + overcloud_images_file)
+                ":5000/"
+            local_url = remote_registry + self.settings.containers_prefix + \
+                manila_container
+            cmds.append('sed -i "s|ContainerManilaShareImage.*|' +
+                        'ContainerManilaShareImage: ' + local_url +
+                        '|" ' + unity_manila_container_yaml)
+            cmds.append('sed -i "s|<undercloud_registry>|' + remote_registry +
+                        '|" ' + unity_manila_container_yaml)
 
         else:
+            undercloud_domain_name = self.settings.director_node.hostname + \
+                                ".ctlplane.localdomain"
             manila_container = "/dellemc/openstack-manila-share-dellemc-rhosp16:" + \
-                           str(self.settings.manila_unity_container_version)
+                               str(self.settings.manila_unity_container_version)
             remote_registry = "registry.connect.redhat.com"
             remote_url = remote_registry + manila_container
             local_registry = self.provisioning_ip + ":8787"
-            local_url = local_registry + manila_container
+            local_registry_domain = undercloud_domain_name + ":8787"
+            local_url = local_registry_domain + manila_container
 
             cmds.extend([
-                'docker login -u ' + self.settings.subscription_manager_user +
+                'sudo podman login -u ' + self.settings.subscription_manager_user +
                 ' -p ' + self.settings.subscription_manager_password +
                 ' ' + remote_registry,
-                'docker pull ' + remote_url,
-                'docker tag ' + remote_url + ' ' + local_url,
-                'docker push ' + local_url,
-                'sed -i "50i \  DockerManilaShareImage: ' + local_url +
-                '" ' + overcloud_images_file,
-                'echo "  DockerInsecureRegistryAddress:" >> ' +
-                overcloud_images_file,
-                'echo "  - ' + local_registry + ' " >> ' +
-                overcloud_images_file,
+                'sudo podman pull ' + remote_url,
+                'sudo openstack tripleo container image push --local ' + remote_url,
+                'sudo podman tag ' + remote_url + ' ' + local_url,
+                'sed -i "s|ContainerManilaShareImage.*|' +
+                'ContainerManilaShareImage: ' + local_url +
+                '|" ' + unity_manila_container_yaml,
+                'sed -i "s|<dellemc_container_registry>|' + local_registry +
+                '|" ' + unity_manila_container_yaml,
+                'sed -i "s|<dellemc_container_registry_domain>|' + local_registry_domain +
+                        '|" ' + unity_manila_container_yaml,
+                'sudo podman logout ' + remote_registry,
             ])
+
         for cmd in cmds:
             self.run_tty(cmd)
 

--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -1001,7 +1001,7 @@ class Director(InfraHost):
             dell_unity_cinder_yaml,
         ]
         if self.settings.use_satellite:
-            cinder_container = "openstack-cinder-volume-dellemc" + \
+            cinder_container = "openstack-cinder-volume-dellemc-rhosp16" + \
                 ':' + str(self.settings.cinder_unity_container_version)
             remote_registry = self.settings.satellite_hostname + \
                 ":5000/" + self.settings.containers_prefix
@@ -1011,7 +1011,7 @@ class Director(InfraHost):
                         '|" ' + overcloud_images_file)
         else:
 
-            cinder_container = "/dellemc/openstack-cinder-volume-dellemc:" + \
+            cinder_container = "/dellemc/openstack-cinder-volume-dellemc-rhosp16:" + \
                 str(self.settings.cinder_unity_container_version)
             remote_registry = "registry.connect.redhat.com"
             remote_url = remote_registry + cinder_container
@@ -1077,7 +1077,7 @@ class Director(InfraHost):
                 ]
 
         if self.settings.use_satellite:
-            manila_container = "openstack-manila-share-dellemc" + \
+            manila_container = "openstack-manila-share-dellemc-rhosp16" + \
                 ':' + str(self.settings.manila_unity_container_version)
             remote_registry = self.settings.satellite_hostname + \
                 ":5000/" + self.settings.containers_prefix
@@ -1086,7 +1086,7 @@ class Director(InfraHost):
                         '" ' + overcloud_images_file)
 
         else:
-            manila_container = "/dellemc/openstack-manila-share-dellemc:" + \
+            manila_container = "/dellemc/openstack-manila-share-dellemc-rhosp16:" + \
                            str(self.settings.manila_unity_container_version)
             remote_registry = "registry.connect.redhat.com"
             remote_url = remote_registry + manila_container

--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -1547,7 +1547,6 @@ class Director(InfraHost):
         # in the neutron-sriov.yaml (sriov environment file)
 
         # Specify number of VFs for sriov mentioned interfaces
-        sriov_vfs_setting = []
         sriov_map_setting = []
         sriov_pci_passthrough = []
         physical_network = ["physint", "physint1", "physint2", "physint3"]
@@ -1573,23 +1572,12 @@ class Director(InfraHost):
 
             sriov_pci_passthrough.append(nova_pci)
 
-            if (self.settings.enable_smart_nic is True):
-                interface = interface + ':' + \
-                                        self.settings.sriov_vf_count + \
-                                        ':switchdev'
-            else:
-                interface = interface + ':' + \
-                                        self.settings.sriov_vf_count
-
-            sriov_vfs_setting.append(interface)
-
-        sriov_vfs_setting = "'" + ",".join(sriov_vfs_setting) + "'"
         sriov_map_setting = "'" + ",".join(sriov_map_setting) + "'"
         sriov_pci_passthrough = "[" + ",".join(sriov_pci_passthrough) + "]"
 
-        cmds.append('sed -i "s|NeutronSriovNumVFs:.*|' +
-                    'NeutronSriovNumVFs: ' +
-                    sriov_vfs_setting + '|" ' + env_file)
+        cmds.append('sed -i "s|NumSriovVfs:.*|' +
+                    'NumSriovVfs: ' +
+                    self.settings.sriov_vf_count + '|" ' + env_file)
         cmds.append('sed -i "s|NeutronPhysicalDevMappings:.*|' +
                     'NeutronPhysicalDevMappings: ' +
                     sriov_map_setting + '|" ' + env_file)

--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -232,13 +232,7 @@ class Director(InfraHost):
             cmd = '~/pilot/install-director.sh --dns ' + \
                   self.settings.name_server + \
                   " --director_ip " + \
-                  self.ip + \
-                  " --sm_user " + \
-                  self.settings.subscription_manager_user + \
-                  " --sm_pwd " + \
-                  self.settings.subscription_manager_password + \
-                  " --sm_pool " + \
-                  self.settings.subscription_manager_vm_ceph
+                  self.ip 
 
         if len(self.settings.overcloud_nodes_pwd) > 0:
             cmd += " --nodes_pwd " + self.settings.overcloud_nodes_pwd

--- a/src/deploy/osp_deployer/settings/config.py
+++ b/src/deploy/osp_deployer/settings/config.py
@@ -622,8 +622,12 @@ class Settings:
             '/pilot/templates/dellsc-cinder-config.yaml'
         self.dell_unity_cinder_yaml = self.foreman_configuration_scripts + \
             '/pilot/templates/dellemc-unity-cinder-backend.yaml'
+        self.dell_unity_cinder_container_yaml = self.foreman_configuration_scripts + \
+            '/pilot/templates/dellemc-unity-cinder-container.yaml'
         self.unity_manila_yaml = self.foreman_configuration_scripts + \
             '/pilot/templates/unity-manila-config.yaml'
+        self.unity_manila_container_yaml = self.foreman_configuration_scripts + \
+            '/pilot/templates/unity-manila-container.yaml'
         self.dell_powermax_iscsi_cinder_yaml = self.foreman_configuration_scripts + \
             '/pilot/templates/dellemc-powermax-iscsi-cinder-backend.yaml'
         self.dell_powermax_fc_cinder_yaml = self.foreman_configuration_scripts + \

--- a/src/deploy/osp_deployer/settings/config.py
+++ b/src/deploy/osp_deployer/settings/config.py
@@ -249,8 +249,6 @@ class Settings:
             'subscription_manager_pool_sah']
         self.subscription_manager_pool_vm_rhel = rhsm_settings[
             'subscription_manager_pool_vm_rhel']
-        self.subscription_manager_vm_ceph = rhsm_settings[
-            'subscription_manager_vm_ceph']
         if 'subscription_check_retries' in rhsm_settings:
             self.subscription_check_retries = rhsm_settings[
                 'subscription_check_retries']

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -165,7 +165,7 @@ satellite_activation_key=sample_key
 
 # Container images can be pulled from satellite rather than cdn if desired
 pull_containers_from_satellite=false
-# Satellite containers prefix, as per https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html/director_installation_and_usage/configuring-a-container-image-source#Configuring-Registry_Details-Satellite
+# Satellite containers prefix, as per https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/director_installation_and_usage/preparing-for-director-installation#preparing-a-satellite-server-for-container-images 
 containers_prefix=organization-product-
 
 
@@ -597,7 +597,7 @@ use_internal_repo=false
 internal_repos_locations=CHANGEME_INTERNAL_REPO_URL
 
 cloud_repo_dir=/root/JetPack
-rhel_iso=/root/rhel77.iso
+rhel_iso=/root/rhel82.iso
 
 # Overcloud deployment timeout value - default is 180mns, but can be tweaked here if required.
 overcloud_deploy_timeout=300

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -154,9 +154,6 @@ subscription_manager_pool_sah=xxxxxxxxxxxxxxxxxxxxxxxxxxxx44f5
 # Red Hat Enterprise Linux OpenStack Platform (Virtual Node)
 subscription_manager_pool_vm_rhel=xxxxxxxxxxxxxxxxxxxxxxxxxxxx454a
 
-# Red Hat Ceph Storage (Physical Node)
-subscription_manager_vm_ceph=xxxxxxxxxxxxxxxxxxxxxxxxxxxx7826
-
 subscription_check_retries=20
 
 # Red Hat Satellite Settings

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -469,9 +469,9 @@ dellsc_multipath_xref=true
 enable_unity_backend=false
 # The Dell EMC Unity Container is published in the RH Container Catalog
 # registry.connect.redhat.com
-# By default, the latest image of the RHOSP release is pulled.
+# By default, this version of the image of the RHOSP release is pulled.
 # Change to a different version if a specific image is required.
-cinder_unity_container_version=latest
+cinder_unity_container_version=16.1-1
 unity_backend_name=CHANGEME
 unity_san_ip=CHANGEME
 unity_san_login=CHANGEME
@@ -487,9 +487,9 @@ unity_storage_pool_names=CHANGEME
 enable_unity_manila_backend=false
 # The Dell EMC Unity Container is published in the RH Container Catalog
 # registry.connect.redhat.com
-# By default, the latest image of the RHOSP release is pulled.
+# By default, this version of the image of the RHOSP release is pulled.
 # Change to a different version if a specific image is required.
-manila_unity_container_version=latest
+manila_unity_container_version=16.1-1
 manila_unity_driver_handles_share_servers=true
 manila_unity_nas_login=CHANGEME
 manila_unity_nas_password=CHANGEME

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -582,7 +582,7 @@ enable_version_locking=false
 # Note that this parameter is defaulted as shown below when commented out or
 # not specified.  It should not be necessary to change it from the default in
 # most cases.
-rhsm_repos=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-highavailability-rpms,ansible-2.8-for-rhel-8-x86_64-rpms,advanced-virt-for-rhel-8-x86_64-rpms,satellite-tools-6.5-for-rhel-8-x86_64-rpms,openstack-16-for-rhel-8-x86_64-rpms,fast-datapath-for-rhel-8-x86_64-rpms,rhceph-4-tools-for-rhel-8-x86_64-rpms
+rhsm_repos=rhel-8-for-x86_64-baseos-eus-rpms,rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-highavailability-eus-rpms,ansible-2.9-for-rhel-8-x86_64-rpms,advanced-virt-for-rhel-8-x86_64-rpms,satellite-tools-6.5-for-rhel-8-x86_64-rpms,openstack-16.1-for-rhel-8-x86_64-rpms,fast-datapath-for-rhel-8-x86_64-rpms
 
 # Option below is to use a custom instack.json and skip discover_nodes
 use_custom_instack_json=false

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -35,6 +35,7 @@ name_server=8.8.8.8
 private_api_network=192.168.140.0/24
 private_api_vlanid=140
 private_api_netmask=255.255.255.0
+private_api_gateway=192.168.140.1
 private_api_allocation_pool_start=192.168.140.121
 private_api_allocation_pool_end=192.168.140.250
 
@@ -42,6 +43,7 @@ private_api_allocation_pool_end=192.168.140.250
 storage_network=192.168.170.0/24
 storage_vlanid=170
 storage_netmask=255.255.255.0
+storage_gateway=192.168.170.1
 storage_allocation_pool_start=192.168.170.125
 storage_allocation_pool_end=192.168.170.250
 
@@ -57,6 +59,7 @@ discovery_ip_range=192.168.120.21,192.168.120.120
 # Storage cluster network details
 storage_cluster_network=192.168.180.0/24
 storage_cluster_vlanid=180
+storage_cluster_gateway=192.168.180.1
 storage_cluster_allocation_pool_start=192.168.180.121
 storage_cluster_allocation_pool_end=192.168.180.250
 
@@ -73,6 +76,7 @@ management_allocation_pool_end=192.168.110.199
 # Tenant network details
 # Not used unless you wish to configure Generic Routing Encapsulation (GRE) networks.
 tenant_tunnel_network=192.168.130.0/24
+tenant_tunnel_gateway=192.168.130.1
 tenant_tunnel_network_allocation_pool_start=192.168.130.121
 tenant_tunnel_network_allocation_pool_end=192.168.130.250
 tenant_tunnel_network_vlanid=130

--- a/src/deploy/osp_deployer/settings/sample_hci_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_hci_profile.ini
@@ -154,9 +154,6 @@ subscription_manager_pool_sah=xxxxxxxxxxxxxxxxxxxxxxxxxxxx44f5
 # Red Hat Enterprise Linux OpenStack Platform (Virtual Node)
 subscription_manager_pool_vm_rhel=xxxxxxxxxxxxxxxxxxxxxxxxxxxx454a
 
-# Red Hat Ceph Storage (Physical Node)
-subscription_manager_vm_ceph=xxxxxxxxxxxxxxxxxxxxxxxxxxxx7826
-
 subscription_check_retries=20
 
 # Red Hat Satellite Settings

--- a/src/deploy/osp_deployer/settings/sample_hci_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_hci_profile.ini
@@ -469,9 +469,9 @@ dellsc_multipath_xref=true
 enable_unity_backend=false
 # The Dell EMC Unity Container is published in the RH Container Catalog
 # registry.connect.redhat.com
-# By default, the latest image of the RHOSP release is pulled.
+# By default, this version of the image of the RHOSP release is pulled.
 # Change to a different version if a specific image is required.
-cinder_unity_container_version=latest
+cinder_unity_container_version=16.1-1
 unity_backend_name=CHANGEME
 unity_san_ip=CHANGEME
 unity_san_login=CHANGEME
@@ -486,9 +486,9 @@ unity_storage_pool_names=CHANGEME
 enable_unity_manila_backend=false
 # The Dell EMC Unity Container is published in the RH Container Catalog
 # registry.connect.redhat.com
-# By default, the latest image of the RHOSP release is pulled.
+# By default, this version of the image of the RHOSP release is pulled.
 # Change to a different version if a specific image is required.
-manila_unity_container_version=latest
+manila_unity_container_version=16.1-1
 manila_unity_driver_handles_share_servers=true
 manila_unity_nas_login=CHANGEME
 manila_unity_nas_password=CHANGEME

--- a/src/deploy/osp_deployer/settings/sample_hci_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_hci_profile.ini
@@ -165,7 +165,7 @@ satellite_activation_key=sample_key
 
 # Container images can be pulled from satellite rather than cdn if desired
 pull_containers_from_satellite=false
-# Satellite containers prefix, as per https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html/director_installation_and_usage/configuring-a-container-image-source#Configuring-Registry_Details-Satellite
+# Satellite containers prefix, as per https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/director_installation_and_usage/preparing-for-director-installation#preparing-a-satellite-server-for-container-images 
 containers_prefix=organization-product-
 
 [Nodes Nics and Bonding Settings]
@@ -570,7 +570,7 @@ use_internal_repo=false
 internal_repos_locations=CHANGEME_INTERNAL_REPO_URL
 
 cloud_repo_dir=/root/JetPack
-rhel_iso=/root/rhel77.iso
+rhel_iso=/root/rhel82.iso
 
 # Overcloud deployment timeout value - default is 180mns, but can be tweaked here if required.
 overcloud_deploy_timeout=300

--- a/src/deploy/osp_deployer/settings/sample_hci_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_hci_profile.ini
@@ -35,6 +35,7 @@ name_server=8.8.8.8
 private_api_network=192.168.140.0/24
 private_api_vlanid=140
 private_api_netmask=255.255.255.0
+private_api_gateway=192.168.140.1
 private_api_allocation_pool_start=192.168.140.121
 private_api_allocation_pool_end=192.168.140.250
 
@@ -42,6 +43,7 @@ private_api_allocation_pool_end=192.168.140.250
 storage_network=192.168.170.0/24
 storage_vlanid=170
 storage_netmask=255.255.255.0
+storage_gateway=192.168.170.1
 storage_allocation_pool_start=192.168.170.125
 storage_allocation_pool_end=192.168.170.250
 
@@ -57,6 +59,7 @@ discovery_ip_range=192.168.120.21,192.168.120.120
 # Storage cluster network details
 storage_cluster_network=192.168.180.0/24
 storage_cluster_vlanid=180
+storage_cluster_gateway=192.168.180.1
 storage_cluster_allocation_pool_start=192.168.180.121
 storage_cluster_allocation_pool_end=192.168.180.250
 
@@ -73,6 +76,7 @@ management_allocation_pool_end=192.168.110.199
 # Tenant network details
 # Not used unless you wish to configure Generic Routing Encapsulation (GRE) networks.
 tenant_tunnel_network=192.168.130.0/24
+tenant_tunnel_gateway=192.168.130.1
 tenant_tunnel_network_allocation_pool_start=192.168.130.121
 tenant_tunnel_network_allocation_pool_end=192.168.130.250
 tenant_tunnel_network_vlanid=130

--- a/src/deploy/osp_deployer/settings/sample_hci_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_hci_profile.ini
@@ -555,7 +555,7 @@ enable_version_locking=false
 # Note that this parameter is defaulted as shown below when commented out or
 # not specified.  It should not be necessary to change it from the default in
 # most cases.
-rhsm_repos=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-highavailability-rpms,ansible-2.8-for-rhel-8-x86_64-rpms,advanced-virt-for-rhel-8-x86_64-rpms,satellite-tools-6.5-for-rhel-8-x86_64-rpms,openstack-16-for-rhel-8-x86_64-rpms,fast-datapath-for-rhel-8-x86_64-rpms,rhceph-4-tools-for-rhel-8-x86_64-rpms
+rhsm_repos=rhel-8-for-x86_64-baseos-eus-rpms,rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-highavailability-eus-rpms,ansible-2.9-for-rhel-8-x86_64-rpms,advanced-virt-for-rhel-8-x86_64-rpms,satellite-tools-6.5-for-rhel-8-x86_64-rpms,openstack-16.1-for-rhel-8-x86_64-rpms,fast-datapath-for-rhel-8-x86_64-rpms
 
 # Option below is to use a custom instack.json and skip discover_nodes
 use_custom_instack_json=false

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -154,9 +154,6 @@ subscription_manager_pool_sah=xxxxxxxxxxxxxxxxxxxxxxxxxxxx44f5
 # Red Hat Enterprise Linux OpenStack Platform (Virtual Node)
 subscription_manager_pool_vm_rhel=xxxxxxxxxxxxxxxxxxxxxxxxxxxx454a
 
-# Red Hat Ceph Storage (Physical Node)
-subscription_manager_vm_ceph=xxxxxxxxxxxxxxxxxxxxxxxxxxxx7826
-
 subscription_check_retries=20
 
 # Red Hat Satellite Settings

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -583,7 +583,7 @@ enable_version_locking=false
 # Note that this parameter is defaulted as shown below when commented out or
 # not specified.  It should not be necessary to change it from the default in
 # most cases.
-rhsm_repos=rhel-8-for-x86_64-baseos-rpms,rhel-8-for-x86_64-appstream-rpms,rhel-8-for-x86_64-highavailability-rpms,ansible-2.8-for-rhel-8-x86_64-rpms,advanced-virt-for-rhel-8-x86_64-rpms,satellite-tools-6.5-for-rhel-8-x86_64-rpms,openstack-16-for-rhel-8-x86_64-rpms,fast-datapath-for-rhel-8-x86_64-rpms,rhceph-4-tools-for-rhel-8-x86_64-rpms
+rhsm_repos=rhel-8-for-x86_64-baseos-eus-rpms,rhel-8-for-x86_64-appstream-eus-rpms,rhel-8-for-x86_64-highavailability-eus-rpms,ansible-2.9-for-rhel-8-x86_64-rpms,advanced-virt-for-rhel-8-x86_64-rpms,satellite-tools-6.5-for-rhel-8-x86_64-rpms,openstack-16.1-for-rhel-8-x86_64-rpms,fast-datapath-for-rhel-8-x86_64-rpms
 
 # Option below is to use a custom instack.json and skip discover_nodes
 use_custom_instack_json=false

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -165,7 +165,7 @@ satellite_activation_key=sample_key
 
 # Container images can be pulled from satellite rather than cdn if desired
 pull_containers_from_satellite=false
-# Satellite containers prefix, as per https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/13/html/director_installation_and_usage/configuring-a-container-image-source#Configuring-Registry_Details-Satellite
+# Satellite containers prefix, as per https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/director_installation_and_usage/preparing-for-director-installation#preparing-a-satellite-server-for-container-images
 containers_prefix=organization-product-
 
 [Nodes Nics and Bonding Settings]
@@ -595,7 +595,7 @@ use_internal_repo=false
 internal_repos_locations=CHANGEME_INTERNAL_REPO_URL
 
 cloud_repo_dir=/root/JetPack
-rhel_iso=/root/rhel77.iso
+rhel_iso=/root/rhel82.iso
 
 # Overcloud deployment timeout value - default is 180mns, but can be tweaked here if required.
 overcloud_deploy_timeout=300

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -59,6 +59,7 @@ discovery_ip_range=192.168.120.21,192.168.120.120
 # Storage cluster network details
 storage_cluster_network=192.168.180.0/24
 storage_cluster_vlanid=180
+storage_cluster_gateway=192.168.180.1
 storage_cluster_allocation_pool_start=192.168.180.121
 storage_cluster_allocation_pool_end=192.168.180.250
 

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -467,9 +467,9 @@ dellsc_multipath_xref=true
 enable_unity_backend=false
 # The Dell EMC Unity Container is published in the RH Container Catalog
 # registry.connect.redhat.com
-# By default, the latest image of the RHOSP release is pulled.
+# By default, this version of the image of the RHOSP release is pulled.
 # Change to a different version if a specific image is required.
-cinder_unity_container_version=latest
+cinder_unity_container_version=16.1-1
 unity_backend_name=CHANGEME
 unity_san_ip=CHANGEME
 unity_san_login=CHANGEME
@@ -485,9 +485,9 @@ unity_storage_pool_names=CHANGEME
 enable_unity_manila_backend=false
 # The Dell EMC Unity Container is published in the RH Container Catalog
 # registry.connect.redhat.com
-# By default, the latest image of the RHOSP release is pulled.
+# By default, this version of the image of the RHOSP release is pulled.
 # Change to a different version if a specific image is required.
-manila_unity_container_version=latest
+manila_unity_container_version=16.1-1
 manila_unity_driver_handles_share_servers=true
 manila_unity_nas_login=CHANGEME
 manila_unity_nas_password=CHANGEME

--- a/src/pilot/config_idrac.py
+++ b/src/pilot/config_idrac.py
@@ -535,7 +535,7 @@ def wait_for_jobs_to_complete(job_ids, drac_client, ip_service_tag):
 
 def clear_job_queue(drac_client, ip_service_tag):
     LOG.info("Clearing the job queue on {}".format(ip_service_tag))
-    drac_client.delete_jobs(job_ids=['JID_CLEARALL_FORCE'])
+    drac_client.delete_jobs(job_ids=['JID_CLEARALL'])
 
     # It takes a second or two for the iDRAC to switch from the ready state to
     # the not-ready state, so wait for this transition to happen

--- a/src/pilot/dell_nfv.py
+++ b/src/pilot/dell_nfv.py
@@ -218,13 +218,14 @@ class ConfigOvercloud(object):
                 if ovs_dpdk:
                     dpdk_nics = self.find_ifaces_by_keyword(nic_env_file,
                                                             'Dpdk')
+                    logger.debug("DPDK-NICs >>" + str(dpdk_nics))
                     self.nfv_params.get_pmd_cpus(mtu, dpdk_nics)
                     self.nfv_params.get_socket_memory(mtu, dpdk_nics)
                 self.nfv_params.get_nova_cpus()
                 self.nfv_params.get_isol_cpus()
-                kernel_args += " isolcpus=%s" % self.nfv_params.nova_cpus
+                kernel_args += " isolcpus=%s" % self.nfv_params.isol_cpus
                 cmds.append(
-                    'sed -i "s|# NovaVcpuPinSet:.*|NovaVcpuPinSet: ' +
+                    'sed -i "s|# NovaComputeCpuDedicatedSet:.*|NovaComputeCpuDedicatedSet: ' +
                     self.nfv_params.nova_cpus + '|" ' + file_path)
             if kernel_args:
                 cmds.append(
@@ -241,6 +242,11 @@ class ConfigOvercloud(object):
                     '\\" |" ' +
                     dpdk_file)
                 cmds.append(
+                    'sed -i "s|NovaComputeCpuSharedSet:.*|NovaComputeCpuSharedSet: \\"' +
+                    self.nfv_params.host_cpus +
+                    '\\" |" ' +
+                    dpdk_file)
+                cmds.append(
                     'sed -i "s|OvsPmdCoreList:.*|OvsPmdCoreList: \\"' +
                     self.nfv_params.pmd_cpus +
                     '\\" |" ' +
@@ -252,8 +258,8 @@ class ConfigOvercloud(object):
                     '\\" |" ' +
                     dpdk_file)
                 cmds.append(
-                    'sed -i "s|# IsolCpusList:.*|IsolCpusList: ' +
-                    self.nfv_params.isol_cpus + '|" ' + dpdk_file)
+                    'sed -i "s|IsolCpusList:.*|IsolCpusList: \\"' +
+                    self.nfv_params.isol_cpus + '\\" |" ' + dpdk_file)
 
             for cmd in cmds:
                 status = os.system(cmd)

--- a/src/pilot/deploy-overcloud.py
+++ b/src/pilot/deploy-overcloud.py
@@ -543,7 +543,11 @@ def main():
 
         if args.node_placement:
             env_opts += " -e ~/pilot/templates/node-placement.yaml"
-
+            
+        # The neutron-ovs.yaml must be included before dell-environment.yaml to enable ovs and disable ovn
+        # in OSP16.1. In case we need to use OVN in future, please delete this line
+        env_opts += " -e ~/pilot/templates/overcloud/environments/services/neutron-ovs.yaml"
+        
         # The dell-environment.yaml must be included after the
         # storage-environment.yaml and ceph-radosgw.yaml
         env_opts += " -e ~/pilot/templates/overcloud/environments/" \
@@ -598,12 +602,9 @@ def main():
         # The network-environment.yaml must be included after other templates
         # for effective parameter overrides (External vlan default route)
         # The network-environment.yaml must be included after the network-isolation.yaml
-        # The neutron-ovs.yaml must be included to enable ovs and disable ovn
-        # in OSP16.1. In case we need to use OVN in future, please delete this line
         env_opts += " -e ~/pilot/templates/overcloud/environments/" \
                     "network-isolation.yaml" \
                     " -e ~/pilot/templates/network-environment.yaml" \
-                    " -e /usr/share/openstack-tripleo-heat-templates/environments/services/neutron-ovs.yaml" \
                     " -e {}".format(nic_env_file)
 
         cmd = "cd ;source ~/stackrc; openstack overcloud deploy" \

--- a/src/pilot/deploy-overcloud.py
+++ b/src/pilot/deploy-overcloud.py
@@ -581,8 +581,12 @@ def main():
 
         if args.enable_unity:
             env_opts += " -e ~/pilot/templates/dellemc-unity-cinder-" \
+                        "container.yaml"
+            env_opts += " -e ~/pilot/templates/dellemc-unity-cinder-" \
                         "backend.yaml"
+
         if args.enable_unity_manila:
+            env_opts += " -e ~/pilot/templates/unity-manila-container.yaml"
             env_opts += " -e ~/pilot/templates/unity-manila-config.yaml"
 
         if args.enable_powermax:

--- a/src/pilot/deploy-overcloud.py
+++ b/src/pilot/deploy-overcloud.py
@@ -597,11 +597,13 @@ def main():
 
         # The network-environment.yaml must be included after other templates
         # for effective parameter overrides (External vlan default route)
-        # The network-environment.yaml must be included after the
-        # network-isolation.yaml
+        # The network-environment.yaml must be included after the network-isolation.yaml
+        # The neutron-ovs.yaml must be included to enable ovs and disable ovn
+        # in OSP16.1. In case we need to use OVN in future, please delete this line
         env_opts += " -e ~/pilot/templates/overcloud/environments/" \
                     "network-isolation.yaml" \
                     " -e ~/pilot/templates/network-environment.yaml" \
+                    " -e /usr/share/openstack-tripleo-heat-templates/environments/services/neutron-ovs.yaml" \
                     " -e {}".format(nic_env_file)
 
         cmd = "cd ;source ~/stackrc; openstack overcloud deploy" \

--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -355,6 +355,21 @@ echo "## Restarting ironic-conductor..."
 sudo podman restart ironic_conductor
 echo "## Done."
 
+
+# Satellite , if using 
+if [ ! -z "${containers_prefix}" ]; then
+    container_yaml=$HOME/containers-prepare-parameter.yaml
+    sed -i "s/namespace:.*/namespace: ${satellite_hostname}:5000/" ${container_yaml}
+    sed -i "s/rhceph-4-dashboard-rhel8/${containers_prefix}rhceph_rhceph-4-dashboard-rhel8/" ${container_yaml}
+    sed -i "s/ose-prometheus-alertmanager/${containers_prefix}openshift4_ose-prometheus-alertmanager/" ${container_yaml}
+    sed -i "s/rhceph-4-rhel8/${containers_prefix}rhceph_rhceph-4-rhel8/" ${container_yaml}
+    sed -i "s/ose-prometheus-node-exporter/${containers_prefix}openshift4_ose-prometheus-node-exporter/" ${container_yaml}
+    sed -i "s/ose-prometheus$/${containers_prefix}openshift4_ose-prometheus/" ${container_yaml}
+    sed -i "s/openstack-/${containers_prefix}rhosp-rhel8_openstack-/" ${container_yaml}
+    sed -i "s/tag_from_label:.*/tag_from_label: '16.1'/" ${container_yaml}
+fi
+
+
 # If deployment is unlocked, generate the overcloud container list from the latest.
 #if [ -e $HOME/overcloud_images.yaml ];
 #then

--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -271,6 +271,13 @@ echo "### Patching tripleo-heat-templates"
 sudo sed -i 's/$(get_python)/python3/' /usr/share/openstack-tripleo-heat-templates/puppet/extraconfig/pre_deploy/per_node.yaml
 echo "## Done."
 
+# Patch a fix for https://bugzilla.redhat.com/show_bug.cgi?id=1846020
+echo "### Patching tripleo-heat-templates part II"
+apply_patch "sudo patch -b -s /usr/share/openstack-tripleo-heat-templates/deployment/swift/swift-proxy-container-puppet.yaml ${HOME}/pilot/swift-proxy-container.patch"
+apply_patch "sudo patch -b -s /usr/share/openstack-tripleo-heat-templates/deployment/nova/nova-scheduler-container-puppet.yaml ${HOME}/pilot/nova-scheduler-container.patch"
+apply_patch "sudo patch -b -s /usr/share/openstack-tripleo-heat-templates/deployment/database/redis-container-puppet.yaml ${HOME}/pilot/redis-container.patch"
+echo "## Done"
+
 echo
 echo "## Copying heat templates..."
 cp -r /usr/share/openstack-tripleo-heat-templates $HOME/pilot/templates/overcloud

--- a/src/pilot/install-director.sh
+++ b/src/pilot/install-director.sh
@@ -17,10 +17,10 @@
 exec > >(tee $HOME/pilot/install-director.log)
 exec 2>&1
 
-USAGE="\nUsing RedHat CDN:$0 --director_ip <director public ip> --dns <dns_ip> --sm_user <subscription_manager_user> --sm_pwd <subscription_manager_pass> [--sm_pool <subcription_manager_poolid>] [--proxy <proxy> --nodes_pwd <overcloud_nodes_password>] \nUsing Satellite:$0 --dns <dns_ip> --satellite_hostname <satellite_host_name> --satellite_org <satellite_organization> --satellite_key <satellite_activation_key> [--containers_prefix <containers_satellite_prefix>] [--proxy <proxy> --nodes_pwd <overcloud_nodes_password>]"
+USAGE="\nUsing RedHat CDN:$0 --director_ip <director public ip> --dns <dns_ip> [--proxy <proxy> --nodes_pwd <overcloud_nodes_password>] \nUsing Satellite:$0 --dns <dns_ip> --satellite_hostname <satellite_host_name> --satellite_org <satellite_organization> --satellite_key <satellite_activation_key> [--containers_prefix <containers_satellite_prefix>] [--proxy <proxy> --nodes_pwd <overcloud_nodes_password>]"
 
 
-TEMP=`getopt -o h --long director_ip:,dns:,sm_user:,sm_pwd:,sm_pool:,proxy:,nodes_pwd:,satellite_hostname:,satellite_org:,satellite_key:,containers_prefix: -n 'install-director.sh' -- "$@"`
+TEMP=`getopt -o h --long director_ip:,dns:,proxy:,nodes_pwd:,satellite_hostname:,satellite_org:,satellite_key:,containers_prefix: -n 'install-director.sh' -- "$@"`
 eval set -- "$TEMP"
 
 
@@ -35,12 +35,6 @@ while true ; do
                 director_public_ip=$2 ; shift 2 ;;
         --dns)
                 dns_ip=$2 ; shift 2 ;;
-        --sm_user)
-                subscription_manager_user=$2 ; shift 2 ;;
-        --sm_pwd)
-                subscription_manager_pass=$2 ; shift 2 ;;
-        --sm_pool)
-                subcription_manager_poolid=$2; shift 2 ;;
         --satellite_hostname)
                 satellite_hostname=$2; shift 2;;
         --satellite_org)
@@ -66,15 +60,6 @@ if [ ! -z "${satellite_hostname}" ]; then
         exit 1
     fi
 
-elif [ ! -z "${subscription_manager_user}" ];then
-
-    if [ -z "${director_public_ip}" ] || [ -z "${dns_ip}" ] || [ -z "${subscription_manager_user}" ] || [ -z "${subscription_manager_pass}" ]; then
-        echo -e "$USAGE"
-        exit 1
-    fi
-else
-    echo -e "$USAGE"
-    exit 1
 fi
 
 
@@ -225,15 +210,11 @@ echo "## Customizing the overcloud image & uploading images"
 if [ ! -z "${satellite_hostname}" ]; then
     run_command "~/pilot/customize_image.sh --director_ip ${director_public_ip} \
                 --satellite_hostname ${satellite_hostname} \
-                --satellite_org ${satellite_org} \
-                --satellite_key ${satellite_key} \
                 --proxy ${proxy}"
 
-elif [ ! -z "${subscription_manager_user}" ];then
+elif [ ! -z "${proxy}" ]; then
     run_command "~/pilot/customize_image.sh --director_ip ${director_public_ip} \
-                --sm_user ${subscription_manager_user} \
-                --sm_pwd ${subscription_manager_pass} \
-                --sm_pool ${subcription_manager_poolid} --proxy ${proxy}"
+                --proxy ${proxy}"
 fi
 
 echo

--- a/src/pilot/network-validation/validate_networks.py
+++ b/src/pilot/network-validation/validate_networks.py
@@ -124,7 +124,7 @@ class NetworkValidation(object):
         os_auth_url, os_tenant_name, os_username, os_password, \
         os_user_domain_name, os_project_domain_name = \
             CredentialHelper.get_undercloud_creds()
-        auth_url = os_auth_url + "v3"
+        auth_url = os_auth_url + "/v3"
 
         kwargs = {'username': os_username,
                   'password': os_password,
@@ -256,7 +256,7 @@ class NetworkValidation(object):
                    "{}@{}".format(self.user, self.ip),
                    "/usr/sbin/ip -4 a"]
             process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-            stdout = process.stdout.read()
+            stdout = process.stdout.read().decode('utf-8')
 
             for network in self.networks:
                 subnet = str(network_to_subnet[network].network)
@@ -302,7 +302,7 @@ class NetworkValidation(object):
                                               source_node.ip),
                                "sudo ping -c 1 -w 2 {}".format(destination_ip)]
                         process = subprocess.Popen(cmd, stdout=subprocess.PIPE)
-                        stdout = process.stdout.read()
+                        stdout = process.stdout.read().decode('utf-8')
                         match = re.search("64 bytes from {0}: icmp_.eq=\d+ "
                                           "ttl=\d+ time=(.*) ms".format(
                                               destination_ip), stdout)

--- a/src/pilot/nfv_parameters.py
+++ b/src/pilot/nfv_parameters.py
@@ -116,7 +116,7 @@ class NfvParameters(object):
                 new_dict[min_val] = value
         # Append Numa cpus to data
             self.data['cpus'][node] = new_dict
-        logger.info("NUMA NICs and CPUs :: " + str(self.data))
+        logger.debug("NUMA NICs and CPUs >> " + str(self.data))
 
     def get_all_cpus(self):
         try:
@@ -130,7 +130,7 @@ class NfvParameters(object):
             total_cpus = [item for sublist in total_cpus for item in sublist]
             total_cpus = self.range_extract(sorted(total_cpus, key=int))
             self.total_cpus = ','.join(map(str, total_cpus))
-            logger.info("Total CPUs >> " + str(self.total_cpus))
+            logger.debug("Total CPUs >> " + str(self.total_cpus))
         except AssertionError:
             raise
 
@@ -144,7 +144,7 @@ class NfvParameters(object):
             i += 1
         host_cpus = self.range_extract(sorted(host_cpus, key=int))
         self.host_cpus = ','.join(map(str, host_cpus))
-        logger.info("Host CPUs >> " + str(self.host_cpus))
+        logger.debug("Host CPUs >> " + str(self.host_cpus))
 
     def get_pmd_cpus(self, mtu, dpdk_nics):
         pmd_cpus = []
@@ -167,6 +167,7 @@ class NfvParameters(object):
         pmd_cpus = [item for sublist in pmd_cpus for item in sublist]
         pmd_cpus = self.range_extract(sorted(pmd_cpus, key=int))
         self.pmd_cpus = ','.join(map(str, pmd_cpus))
+        logger.debug("PMD CPUs >> " + str(self.pmd_cpus))
 
     def get_nova_cpus(self):
         nova_cpus = []
@@ -178,7 +179,7 @@ class NfvParameters(object):
         nova_cpus = [item for sublist in nova_cpus for item in sublist]
         nova_cpus = self.range_extract(sorted(nova_cpus, key=int))
         self.nova_cpus = ','.join(map(str, nova_cpus))
-        logger.info("NOVA CPUs >> " + str(self.nova_cpus))
+        logger.debug("NOVA CPUs >> " + str(self.nova_cpus))
 
     def get_isol_cpus(self):
         isol_cpus = []
@@ -188,6 +189,7 @@ class NfvParameters(object):
         isol_cpus = sorted(map(int, isol_cpus), key=int)
         isol_cpus = self.range_extract(isol_cpus)
         self.isol_cpus = ','.join(map(str, isol_cpus))
+        logger.debug("isol CPUs >> " + str(self.isol_cpus))
 
     def get_socket_memory(self, mtu, dpdk_nics):
         nodes = self.data['nics'].keys()
@@ -200,7 +202,7 @@ class NfvParameters(object):
                     mem += (mtu + 800) * (4096*64)
                     break
             mem = mem / (1024*1024)
-            numa_mem[n] = self.round_to_nearest(mem, 1024)
+            numa_mem[n] = int(self.round_to_nearest(mem, 1024))
         self.socket_mem = ','.join(map(str, numa_mem.values()))
 
     def round_to_nearest(self, n, m):

--- a/src/pilot/nfv_parameters.py
+++ b/src/pilot/nfv_parameters.py
@@ -106,12 +106,22 @@ class NfvParameters(object):
 
     def parse_data(self, node_data):
         self.data['nics'] = self.get_numa_nics(node_data)
-        self.data['cpus'] = self.get_numa_cpus(node_data)
+        cpus = self.get_numa_cpus(node_data)
+        # Reorganize cpus keys to be in numeric order
+        for node in cpus.keys():
+            new_dict = {}
+            cpu_dict = cpus[node]
+            for key,value in cpu_dict.items():
+                min_val = min(value)        #extract min values
+                new_dict[min_val] = value
+        # Append Numa cpus to data
+            self.data['cpus'][node] = new_dict
+        logger.info("NUMA NICs and CPUs :: " + str(self.data))
 
     def get_all_cpus(self):
         try:
             total_cpus = []
-            assert self.data.has_key('cpus'),\
+            assert 'cpus' in self.data,\
                 "Unable to fetch total number " \
                 "of CPUs. Parse CPU data first"
             for node in self.data['cpus'].keys():
@@ -120,6 +130,7 @@ class NfvParameters(object):
             total_cpus = [item for sublist in total_cpus for item in sublist]
             total_cpus = self.range_extract(sorted(total_cpus, key=int))
             self.total_cpus = ','.join(map(str, total_cpus))
+            logger.info("Total CPUs >> " + str(self.total_cpus))
         except AssertionError:
             raise
 
@@ -133,6 +144,7 @@ class NfvParameters(object):
             i += 1
         host_cpus = self.range_extract(sorted(host_cpus, key=int))
         self.host_cpus = ','.join(map(str, host_cpus))
+        logger.info("Host CPUs >> " + str(self.host_cpus))
 
     def get_pmd_cpus(self, mtu, dpdk_nics):
         pmd_cpus = []
@@ -166,6 +178,7 @@ class NfvParameters(object):
         nova_cpus = [item for sublist in nova_cpus for item in sublist]
         nova_cpus = self.range_extract(sorted(nova_cpus, key=int))
         self.nova_cpus = ','.join(map(str, nova_cpus))
+        logger.info("NOVA CPUs >> " + str(self.nova_cpus))
 
     def get_isol_cpus(self):
         isol_cpus = []

--- a/src/pilot/nova-scheduler-container.patch
+++ b/src/pilot/nova-scheduler-container.patch
@@ -1,0 +1,10 @@
+--- /usr/share/openstack-tripleo-heat-templates/deployment/nova/nova-scheduler-container-puppet.yaml	2020-05-29 17:32:38.000000000 -0500
++++ nova-scheduler-container-puppet.yaml.new	2020-08-06 17:17:54.934974040 -0500
+@@ -212,7 +212,6 @@
+                 -
+                   - /var/lib/kolla/config_files/nova_scheduler.json:/var/lib/kolla/config_files/config.json:ro
+                   - /var/lib/config-data/puppet-generated/nova:/var/lib/kolla/config_files/src:ro
+-                  - /run:/run
+             environment:
+               KOLLA_CONFIG_STRATEGY: COPY_ALWAYS
+       deploy_steps_tasks:

--- a/src/pilot/redis-container.patch
+++ b/src/pilot/redis-container.patch
@@ -1,0 +1,10 @@
+--- /usr/share/openstack-tripleo-heat-templates/deployment/database/redis-container-puppet.yaml	2020-05-18 05:32:49.000000000 -0500
++++ redis-container-puppet.yaml	2020-08-06 17:17:40.885504028 -0500
+@@ -173,7 +173,6 @@
+                 healthcheck:
+                   test: /openstack/healthcheck
+                 volumes:
+-                  - /run:/run
+                   - /var/lib/kolla/config_files/redis.json:/var/lib/kolla/config_files/config.json:ro
+                   - /var/lib/config-data/puppet-generated/redis:/var/lib/kolla/config_files/src:ro
+                   - /etc/localtime:/etc/localtime:ro

--- a/src/pilot/register_overcloud.py
+++ b/src/pilot/register_overcloud.py
@@ -29,7 +29,7 @@ from keystoneclient.v3 import client
 from credential_helper import CredentialHelper
 from netaddr import IPAddress
 from network_helper import NetworkHelper
-
+from ironic_helper import IronicHelper
 
 class RegisterOvercloud:
 
@@ -49,9 +49,9 @@ class RegisterOvercloud:
         stdout, stderr = process.communicate()
         self.logger.debug("Got back:\n" +
                           "    returncode=" + str(process.returncode) + "\n"
-                          "    stdout=" + stdout)
+                          "    stdout=" + stdout.decode('utf-8'))
 
-        return process.returncode, stdout
+        return process.returncode, stdout.decode('utf-8')
 
     def __init__(self):
         logging.basicConfig()
@@ -163,12 +163,12 @@ class RegisterOvercloud:
         provisioning_network = NetworkHelper.get_provisioning_network()
 
         kwargs = {'os_username': os_username,
-                  'os_password': os_password,
-                  'os_auth_url': os_auth_url,
-                  'os_tenant_name': os_tenant_name,
-                  'os_user_domain_name': os_user_domain_name,
-                  'os_project_domain_name': os_project_domain_name}
-        i_client = ironic_client.get_client(1, **kwargs)
+              'os_password': os_password,
+              'os_auth_url': os_auth_url,
+              'os_tenant_name': os_tenant_name,
+              'os_user_domain_name': os_user_domain_name,
+              'os_project_domain_name': os_project_domain_name}
+        i_client = IronicHelper.get_ironic_client()
 
         auth = v3.Password(
             auth_url=auth_url,

--- a/src/pilot/subscription.json
+++ b/src/pilot/subscription.json
@@ -21,35 +21,36 @@
     "roles": {
         "control": {
             "pool_ids": [ "CHANGEME_openstack_pool_id" ],
-            "repos": [ "rhel-7-server-rpms",
-                       "rhel-7-server-extras-rpms",
-                       "rhel-ha-for-rhel-7-server-rpms",
-                       "rhel-7-server-openstack-13-rpms",
-                       "rhel-7-server-openstack-13-devtools-rpms",
-                       "rhel-7-server-rhceph-3-mon-rpms",
-                       "rhel-7-server-rhceph-3-tools-rpms" ]
+            "repos": [ "rhel-8-for-x86_64-baseos-eus-rpms",
+						"rhel-8-for-x86_64-appstream-eus-rpms",
+						"rhel-8-for-x86_64-highavailability-eus-rpms",
+						"ansible-2.9-for-rhel-8-x86_64-rpms",
+						"advanced-virt-for-rhel-8-x86_64-rpms",
+						"satellite-tools-6.5-for-rhel-8-x86_64-rpms",
+						"openstack-16.1-for-rhel-8-x86_64-rpms",
+						"fast-datapath-for-rhel-8-x86_64-rpms"  ]
         },
         "compute": {
             "pool_ids": [ "CHANGEME_openstack_pool_id" ],
-            "repos": [ "rhel-7-server-rpms",
-                       "rhel-7-server-extras-rpms",
-                       "rhel-ha-for-rhel-7-server-rpms",
-                       "rhel-7-server-openstack-13-rpms",
-                       "rhel-7-server-openstack-13-devtools-rpms",
-                       "rhel-7-server-rhceph-3-mon-rpms",
-                       "rhel-7-server-rhceph-3-tools-rpms" ]
+            "repos": [ "rhel-8-for-x86_64-baseos-eus-rpms",
+						"rhel-8-for-x86_64-appstream-eus-rpms",
+						"rhel-8-for-x86_64-highavailability-eus-rpms",
+						"ansible-2.9-for-rhel-8-x86_64-rpms",
+						"advanced-virt-for-rhel-8-x86_64-rpms",
+						"satellite-tools-6.5-for-rhel-8-x86_64-rpms",
+						"openstack-16.1-for-rhel-8-x86_64-rpms",
+						"fast-datapath-for-rhel-8-x86_64-rpms"  ]
         },
         "ceph-storage": {
-            "pool_ids": [ "CHANGEME_openstack_pool_id",
-                          "CHANGEME_ceph_pool_id" ],
-            "repos": [ "rhel-7-server-rpms",
-                       "rhel-7-server-extras-rpms",
-                       "rhel-ha-for-rhel-7-server-rpms",
-                       "rhel-7-server-openstack-13-rpms",
-                       "rhel-7-server-openstack-13-devtools-rpms",
-                       "rhel-7-server-rhceph-3-mon-rpms",
-                       "rhel-7-server-rhceph-3-osd-rpms",
-                       "rhel-7-server-rhceph-3-tools-rpms" ]
+            "pool_ids": [ "CHANGEME_openstack_pool_id"],
+            "repos": [  "rhel-8-for-x86_64-baseos-eus-rpms",
+						"rhel-8-for-x86_64-appstream-eus-rpms",
+						"rhel-8-for-x86_64-highavailability-eus-rpms",
+						"ansible-2.9-for-rhel-8-x86_64-rpms",
+						"advanced-virt-for-rhel-8-x86_64-rpms",
+						"satellite-tools-6.5-for-rhel-8-x86_64-rpms",
+						"openstack-16.1-for-rhel-8-x86_64-rpms",
+						"fast-datapath-for-rhel-8-x86_64-rpms" ]
         }
     }
 }

--- a/src/pilot/subscription.json
+++ b/src/pilot/subscription.json
@@ -20,37 +20,16 @@
     },
     "roles": {
         "control": {
-            "pool_ids": [ "CHANGEME_openstack_pool_id" ],
-            "repos": [ "rhel-8-for-x86_64-baseos-eus-rpms",
-						"rhel-8-for-x86_64-appstream-eus-rpms",
-						"rhel-8-for-x86_64-highavailability-eus-rpms",
-						"ansible-2.9-for-rhel-8-x86_64-rpms",
-						"advanced-virt-for-rhel-8-x86_64-rpms",
-						"satellite-tools-6.5-for-rhel-8-x86_64-rpms",
-						"openstack-16.1-for-rhel-8-x86_64-rpms",
-						"fast-datapath-for-rhel-8-x86_64-rpms"  ]
+            "pool_ids": [ "CHANGEME_RHEL_8_pool_id" ],
+            "repos": [ "rhel-8-for-x86_64-baseos-eus-rpms" ]
         },
         "compute": {
-            "pool_ids": [ "CHANGEME_openstack_pool_id" ],
-            "repos": [ "rhel-8-for-x86_64-baseos-eus-rpms",
-						"rhel-8-for-x86_64-appstream-eus-rpms",
-						"rhel-8-for-x86_64-highavailability-eus-rpms",
-						"ansible-2.9-for-rhel-8-x86_64-rpms",
-						"advanced-virt-for-rhel-8-x86_64-rpms",
-						"satellite-tools-6.5-for-rhel-8-x86_64-rpms",
-						"openstack-16.1-for-rhel-8-x86_64-rpms",
-						"fast-datapath-for-rhel-8-x86_64-rpms"  ]
+            "pool_ids": [ "CHANGEME_RHEL_8_pool_id" ],
+            "repos": [ "rhel-8-for-x86_64-baseos-eus-rpms" ]
         },
         "ceph-storage": {
-            "pool_ids": [ "CHANGEME_openstack_pool_id"],
-            "repos": [  "rhel-8-for-x86_64-baseos-eus-rpms",
-						"rhel-8-for-x86_64-appstream-eus-rpms",
-						"rhel-8-for-x86_64-highavailability-eus-rpms",
-						"ansible-2.9-for-rhel-8-x86_64-rpms",
-						"advanced-virt-for-rhel-8-x86_64-rpms",
-						"satellite-tools-6.5-for-rhel-8-x86_64-rpms",
-						"openstack-16.1-for-rhel-8-x86_64-rpms",
-						"fast-datapath-for-rhel-8-x86_64-rpms" ]
+            "pool_ids": [ "CHANGEME_RHEL_8_pool_id"],
+            "repos": [  "rhel-8-for-x86_64-baseos-eus-rpms" ]
         }
     }
 }

--- a/src/pilot/swift-proxy-container.patch
+++ b/src/pilot/swift-proxy-container.patch
@@ -1,0 +1,10 @@
+--- /usr/share/openstack-tripleo-heat-templates/deployment/swift/swift-proxy-container-puppet.yaml	2020-05-18 05:32:49.000000000 -0500
++++ swift-proxy-container-puppet.yaml.new	2020-08-06 17:17:07.162375854 -0500
+@@ -402,7 +402,6 @@
+                     -
+                       - /var/lib/kolla/config_files/swift_proxy.json:/var/lib/kolla/config_files/config.json:ro
+                       - /var/lib/config-data/puppet-generated/swift:/var/lib/kolla/config_files/src:ro
+-                      - /run:/run
+                       - /srv/node:/srv/node
+                       - /dev:/dev
+                       - /var/log/containers/swift:/var/log/swift:z

--- a/src/pilot/templates/dell-environment.yaml
+++ b/src/pilot/templates/dell-environment.yaml
@@ -47,7 +47,7 @@ parameter_defaults:
   # List of Default Filters to pass to the nova Scheduler
   # Default filters are used if profile is set to XSP
   # This line is uncommented when using with CSP profile
-  # NovaSchedulerDefaultFilters: ['RetryFilter','AvailabilityZoneFilter','ComputeFilter','ComputeCapabilitiesFilter','ImagePropertiesFilter','ServerGroupAntiAffinityFilter','ServerGroupAffinityFilter','NUMATopologyFilter', 'AggregateInstanceExtraSpecsFilter']
+  # NovaSchedulerDefaultFilters: ['RetryFilter','AvailabilityZoneFilter','ComputeFilter','ComputeCapabilitiesFilter','ImagePropertiesFilter','ServerGroupAntiAffinityFilter','ServerGroupAffinityFilter','NUMATopologyFilter','AggregateInstanceExtraSpecsFilter']
 
   # List or range of physical CPU cores to reserve for virtual machine processes.
   # This parameter is depricated in 16.1. In the future releases, use

--- a/src/pilot/templates/dell-environment.yaml
+++ b/src/pilot/templates/dell-environment.yaml
@@ -50,11 +50,9 @@ parameter_defaults:
   # NovaSchedulerDefaultFilters: ['RetryFilter','AvailabilityZoneFilter','ComputeFilter','ComputeCapabilitiesFilter','ImagePropertiesFilter','ServerGroupAntiAffinityFilter','ServerGroupAffinityFilter','NUMATopologyFilter','AggregateInstanceExtraSpecsFilter']
 
   # List or range of physical CPU cores to reserve for virtual machine processes.
-  # This parameter is depricated in 16.1. In the future releases, use
-  # NovaComputeCpuDedicatedSet and NovaComputeCpuSharedSet instead. 
   # Disabled by default for XSP Profile
   # This line is uncommented and updated when using CSP Profile
-  # NovaVcpuPinSet: "8-23,32-47"
+  # NovaComputeCpuDedicatedSet: "8-23,32-47"
   # DellComputeParameters:
     # KernelArgs: "default_hugepagesz=1GB hugepagesz=1G hugepages=176 iommu=pt intel_iommu=on"
 

--- a/src/pilot/templates/dell-environment.yaml
+++ b/src/pilot/templates/dell-environment.yaml
@@ -49,7 +49,9 @@ parameter_defaults:
   # This line is uncommented when using with CSP profile
   # NovaSchedulerDefaultFilters: ['RetryFilter','AvailabilityZoneFilter','ComputeFilter','ComputeCapabilitiesFilter','ImagePropertiesFilter','ServerGroupAntiAffinityFilter','ServerGroupAffinityFilter','NUMATopologyFilter', 'AggregateInstanceExtraSpecsFilter']
 
-  # List of CPUs reserver for Host OS operation
+  # List or range of physical CPU cores to reserve for virtual machine processes.
+  # This parameter is depricated in 16.1. In the future releases, use
+  # NovaComputeCpuDedicatedSet and NovaComputeCpuSharedSet instead. 
   # Disabled by default for XSP Profile
   # This line is uncommented and updated when using CSP Profile
   # NovaVcpuPinSet: "8-23,32-47"

--- a/src/pilot/templates/dellemc-powermax-fc-cinder-backend.yaml
+++ b/src/pilot/templates/dellemc-powermax-fc-cinder-backend.yaml
@@ -10,7 +10,7 @@ parameter_defaults:
         tripleo_dellemc_powermax/san_login:
             value: <powermax_san_login>
         tripleo_dellemc_powermax/san_password:
-            value: <tripleo_dellemc_powermax_san_password>
+            value: <powermax_san_password>
         tripleo_dellemc_powermax/vmax_port_groups:
             value: '<powermax_port_groups>'
         tripleo_dellemc_powermax/vmax_array:

--- a/src/pilot/templates/dellemc-powermax-iscsi-cinder-backend.yaml
+++ b/src/pilot/templates/dellemc-powermax-iscsi-cinder-backend.yaml
@@ -1,5 +1,5 @@
 parameter_defaults: 
-  CinderEnableIscsiBackend:true
+  CinderEnableIscsiBackend: false
 
 parameter_defaults:
   ControllerExtraConfig:

--- a/src/pilot/templates/dellemc-unity-cinder-backend.yaml
+++ b/src/pilot/templates/dellemc-unity-cinder-backend.yaml
@@ -6,9 +6,9 @@ resource_registry:
 parameter_defaults:
   CinderEnableDellEMCUnityBackend: true
   CinderDellEMCUnityBackendName: 'tripleo_dellemc_unity'
-  CinderDellEMCUnitySanIp: <unity_san_ip>
-  CinderDellEMCUnitySanLogin: <unity_san_login>
-  CinderDellEMCUnitySanPassword: <unity_san_password>
-  CinderDellEMCUnityStorageProtocol: <unity_storage_protocol>
-  CinderDellEMCUnityIoPorts: <unity_io_ports>
-  CinderDellEMCUnityStoragePoolNames: <unity_storage_pool_names>
+  CinderDellEMCUnitySanIp: '<unity_san_ip>'
+  CinderDellEMCUnitySanLogin: '<unity_san_login>'
+  CinderDellEMCUnitySanPassword: '<unity_san_password>'
+  CinderDellEMCUnityStorageProtocol: '<unity_storage_protocol>'
+  CinderDellEMCUnityIoPorts: '<unity_io_ports>'
+  CinderDellEMCUnityStoragePoolNames: '<unity_storage_pool_names>'

--- a/src/pilot/templates/dellemc-unity-cinder-container.yaml
+++ b/src/pilot/templates/dellemc-unity-cinder-container.yaml
@@ -1,0 +1,2 @@
+parameter_defaults:
+  ContainerCinderVolumeImage: <dellemc_container_registry_domain>/dellemc/openstack-cinder-volume-dellemc-rhosp16:16.1-1

--- a/src/pilot/templates/neutron-ovs-dpdk.yaml
+++ b/src/pilot/templates/neutron-ovs-dpdk.yaml
@@ -22,7 +22,7 @@ parameter_defaults:
   NeutronVhostuserSocketDir: "/var/lib/vhost_sockets"
 # DELL-NFV Overrides
   NovaSchedulerDefaultFilters: "ComputeFilter,AvailabilityZoneFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,NUMATopologyFilter"
-  OvsDpdkDriverType: "mlx5_core"
+  OvsDpdkDriverType: "mlx5_core" 
   NeutronPluginExtensions: "qos,port_security"
   NeutronOVSFirewallDriver: openvswitch
   DellComputeParameters:
@@ -35,9 +35,9 @@ parameter_defaults:
     NovaReservedHostMemory: 4096
     OvsDpdkSocketMemory: "2048,2048"
     TunedProfileName: "cpu-partitioning"
-    NumDpdkInterfaceRxQueues: 1
-    OvsEnableDpdk: true
- DellComputeHCIParameters:
+    NovaLibvirtRxQueueSize: 1024
+    NovaLibvirtTxQueueSize: 1024
+  DellComputeHCIParameters:
     VhostuserSocketGroup: "hugetlbfs"
     OvsPmdCoreList: "4-7,28-31"
     OvsDpdkCoreList: "0-3,24-27"
@@ -47,5 +47,6 @@ parameter_defaults:
     NovaReservedHostMemory: 4096
     OvsDpdkSocketMemory: "2048,2048"
     TunedProfileName: "cpu-partitioning"
-    NumDpdkInterfaceRxQueues: 1
-    OvsEnableDpdk: true
+    NovaLibvirtRxQueueSize: 1024
+    NovaLibvirtTxQueueSize: 1024
+

--- a/src/pilot/templates/neutron-ovs-dpdk.yaml
+++ b/src/pilot/templates/neutron-ovs-dpdk.yaml
@@ -29,6 +29,7 @@ parameter_defaults:
     VhostuserSocketGroup: "hugetlbfs"
     OvsPmdCoreList: "4-7,28-31"
     OvsDpdkCoreList: "0-3,24-27"
+    NovaComputeCpuSharedSet: "0-3,40-43"
     IsolCpusList: "4-23,28-47"
     OvsDpdkMemoryChannels: "4"
     NovaReservedHostMemory: 4096
@@ -40,6 +41,7 @@ parameter_defaults:
     VhostuserSocketGroup: "hugetlbfs"
     OvsPmdCoreList: "4-7,28-31"
     OvsDpdkCoreList: "0-3,24-27"
+    NovaComputeCpuSharedSet: "0-3,40-43"
     IsolCpusList: "4-23,28-47"
     OvsDpdkMemoryChannels: "4"
     NovaReservedHostMemory: 4096

--- a/src/pilot/templates/neutron-ovs-dpdk.yaml
+++ b/src/pilot/templates/neutron-ovs-dpdk.yaml
@@ -21,7 +21,7 @@ parameter_defaults:
   NeutronDatapathType: "netdev"
   NeutronVhostuserSocketDir: "/var/lib/vhost_sockets"
 # DELL-NFV Overrides
-  NovaSchedulerDefaultFilters: "RamFilter,ComputeFilter,AvailabilityZoneFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,NUMATopologyFilter"
+  NovaSchedulerDefaultFilters: "ComputeFilter,AvailabilityZoneFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,NUMATopologyFilter"
   OvsDpdkDriverType: "mlx5_core"
   NeutronPluginExtensions: "qos,port_security"
   NeutronOVSFirewallDriver: openvswitch

--- a/src/pilot/templates/neutron-sriov.yaml
+++ b/src/pilot/templates/neutron-sriov.yaml
@@ -4,7 +4,7 @@ resource_registry:
   OS::TripleO::Services::NeutronSriovHostConfig: ./overcloud/puppet/services/neutron-sriov-host-config.yaml
 parameter_defaults:
   NeutronMechanismDrivers: ['sriovnicswitch', 'openvswitch']
-  NovaSchedulerDefaultFilters: ['RetryFilter','AvailabilityZoneFilter','RamFilter','ComputeFilter','ComputeCapabilitiesFilter','ImagePropertiesFilter','ServerGroupAntiAffinityFilter','ServerGroupAffinityFilter','PciPassthroughFilter']
+  NovaSchedulerDefaultFilters: ['RetryFilter','AvailabilityZoneFilter','ComputeFilter','ComputeCapabilitiesFilter','ImagePropertiesFilter','ServerGroupAntiAffinityFilter','ServerGroupAffinityFilter','PciPassthroughFilter','AggregateInstanceExtraSpecsFilter']
   NovaSchedulerAvailableFilters: ["nova.scheduler.filters.all_filters","nova.scheduler.filters.pci_passthrough_filter.PciPassthroughFilter"]
   NeutronEnableIsolatedMetadata: true
   NeutronEnableForceMetadata: true

--- a/src/pilot/templates/neutron-sriov.yaml
+++ b/src/pilot/templates/neutron-sriov.yaml
@@ -1,7 +1,7 @@
 ## A Heat environment that can be used to deploy SR-IOV
 resource_registry:
-  OS::TripleO::Services::NeutronSriovAgent: ./overcloud/docker/services/neutron-sriov-agent.yaml
-  OS::TripleO::Services::NeutronSriovHostConfig: ./overcloud/puppet/services/neutron-sriov-host-config.yaml
+  OS::TripleO::Services::NeutronSriovAgent: ./overcloud/deployment/neutron/neutron-sriov-agent-container-puppet.yaml
+  OS::TripleO::Services::NeutronSriovHostConfig: ./overcloud/deployment/deprecated/neutron/neutron-sriov-host-config.yaml
 parameter_defaults:
   NeutronMechanismDrivers: ['sriovnicswitch', 'openvswitch']
   NovaSchedulerDefaultFilters: ['RetryFilter','AvailabilityZoneFilter','ComputeFilter','ComputeCapabilitiesFilter','ImagePropertiesFilter','ServerGroupAntiAffinityFilter','ServerGroupAffinityFilter','PciPassthroughFilter','AggregateInstanceExtraSpecsFilter']
@@ -9,6 +9,6 @@ parameter_defaults:
   NeutronEnableIsolatedMetadata: true
   NeutronEnableForceMetadata: true
   NeutronTunnelTypes: ''
-  NeutronSriovNumVFs: 
-  NeutronPhysicalDevMappings: 
-  NovaPCIPassthrough: 
+  NumSriovVfs:
+  NeutronPhysicalDevMappings:
+  NovaPCIPassthrough:

--- a/src/pilot/templates/nic-configs/ovs-dpdk_6_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_6_port/controller.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for controller nodes.
+  Bond and VLAN configuration for controller nodes. comment14_0: ' The values of the following parameters are overridden by
+  the entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -104,35 +154,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -152,7 +208,7 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                    get_param: ProvisioningMtu
                 use_dhcp: false
                 addresses:
                 - ip_netmask:
@@ -183,7 +239,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -191,19 +247,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -212,7 +268,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -221,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -231,32 +287,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_6_port/dellcompute_dpdk.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_6_port/dellcompute_dpdk.yaml
@@ -50,15 +50,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -109,35 +142,45 @@ parameters:
     default: mlx5_core
     description: DPDK driver for Mellanox
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  NumDpdkInterfaceRxQueues:
+    description: Number of Rx Queues required for DPDK bond or DPDK ports
+    default: 1
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -159,7 +202,7 @@ resources:
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -181,19 +224,19 @@ resources:
                   name:
                     get_param: ComputeBond0Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond0
                 vlan_id:
                   get_param: TenantNetworkVlanID
                 mtu:
-                  get_param: TenantNetworkMTU
+                  get_param: TenantMtu
                 addresses:
                 - ip_netmask:
                     get_param: TenantIpSubnet
@@ -202,67 +245,69 @@ resources:
                 vlan_id:
                   get_param: InternalApiNetworkVlanID
                 mtu:
-                  get_param: InternalApiMTU
+                  get_param: InternalApiMtu
                 addresses:
                 - ip_netmask:
                     get_param: InternalApiIpSubnet
               - type: ovs_user_bridge
                 name: br-tenant
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: DefaultBondMtu
                 use_dhcp: false
                 members:
                 - type: ovs_dpdk_bond
-                  name: ovs_dpdk_bond10
+                  name: dpdkbond0
+                  rx_queue:
+                    get_param: NumDpdkInterfaceRxQueues
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   ovs_options:
                     get_param: BondInterfaceOvsOptions
                   members:
                   - type: ovs_dpdk_port
                     name: dpdk0
+                    mtu:
+                        get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface1
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk1
+                    mtu:
+                        get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface2
-                      mtu:
-                        get_param: DefaultBondMTU
               - type: linux_bond
                 name: bond1
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond1
                 vlan_id:
                   get_param: StorageNetworkVlanID
                 mtu:
-                  get_param: StorageNetworkMTU
+                  get_param: StorageMtu
                 addresses:
                 - ip_netmask:
                     get_param: StorageIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_6_port/nic_environment.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_6_port/nic_environment.yaml
@@ -19,44 +19,37 @@ resource_registry:
 
 
 parameter_defaults:
-  # CHANGEME: Change the interface names in the following lines for the
-  # controller nodes provisioning interface and to include in the controller
-  # nodes bonds
-  #ControllerProvisioningInterface: em3
-  ControllerBond0Interface1: em1
-  ControllerBond0Interface2: p3p1
-  ControllerBond1Interface1: em2
-  ControllerBond1Interface2: p3p2
+  # CHANGEME: Change the interface names in the following lines
+  # to include in the controller nodes bonds
+  ControllerBond0Interface1: ens5f0
+  ControllerBond0Interface2: ens7f0
+  ControllerBond1Interface1: ens5f1
+  ControllerBond1Interface2: ens7f1
   # The bonding mode to use for controller nodes
   ControllerBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
-  # CHANGEME: Change the interface names in the following lines for the
-  # compute nodes provisioning interface and to include in the compute
-  # nodes bonds
-  #ComputeProvisioningInterface: em3
-  ComputeBond0Interface1: em1
-  ComputeBond0Interface2: p3p1
-  ComputeBond1Interface1: em2
-  ComputeBond1Interface2: p3p2
+  # CHANGEME: Change the interface names in the following lines
+  # to include in the compute nodes bonds
+  ComputeBond0Interface1: ens5f0
+  ComputeBond0Interface2: ens3f0
+  ComputeBond1Interface1: ens5f1
+  ComputeBond1Interface2: ens3f1
   # The bonding mode to use for compute nodes
   ComputeBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
-  # CHANGEME: Change the interface names in the following lines for the
-  # compute nodes provisioning interface and to include in the compute
-  # DPDK bonds
-  ComputeOvsDpdkInterface1: p2p1
-  ComputeOvsDpdkInterface2: p3p1
+  # CHANGEME: Change the interface names in the following lines 
+  # for the compute DPDK bonds
+  ComputeOvsDpdkInterface1: ens4f0
+  ComputeOvsDpdkInterface2: ens4f1
   # The DPDK bonding mode to use for compute nodes
   BondInterfaceOvsOptions: bond_mode=balance-tcp lacp=active
   HostNicDriver: mlx5_core
   
-  # CHANGEME: Change the interface names in the following lines for the
-  # storage nodes provisioning interface and to include in the storage
-  # nodes bonds
-  #StorageProvisioningInterface: em3
-  StorageBond0Interface1: em1
-  StorageBond0Interface2: p2p1
-  StorageBond1Interface1: em2
-  StorageBond1Interface2: p2p2
+  # CHANGEME: Change the interface names in the following lines
+  # to include in the storage nodes bonds
+  StorageBond0Interface1: ens1f0
+  StorageBond0Interface2: ens2f0
+  StorageBond1Interface1: ens1f1
+  StorageBond1Interface2: ens2f1
   # The bonding mode to use for storage nodes
   StorageBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1

--- a/src/pilot/templates/nic-configs/ovs-dpdk_6_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_6_port/storage.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for storage nodes.
+  Bond and VLAN configuration for storage nodes. comment14_0: ' The values of the following parameters are overridden by the
+  entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,15 +55,40 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -96,31 +122,37 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -139,11 +171,11 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-bond0
-                mtu:
-                  get_param: ProvisioningNetworkMTU
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
+                mtu:
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -161,7 +193,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -169,51 +201,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_7_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_7_port/controller.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for controller nodes.
+  Bond and VLAN configuration for controller nodes. comment14_0: ' The values of the following parameters are overridden by
+  the entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -108,35 +158,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -156,9 +212,9 @@ resources:
               - type: interface
                 name:
                   get_param: ControllerProvisioningInterface
-                mtu:
-                  get_param: ProvisioningNetworkMTU
                 use_dhcp: false
+                mtu:
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -187,12 +243,12 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -200,19 +256,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -221,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -230,7 +286,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -240,32 +296,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_7_port/dellcompute_dpdk.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_7_port/dellcompute_dpdk.yaml
@@ -50,15 +50,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -113,35 +146,45 @@ parameters:
     default: mlx5_core
     description: DPDK driver for Mellanox
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  NumDpdkInterfaceRxQueues:
+    description: Number of Rx Queues required for DPDK bond or DPDK ports
+    default: 1
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -162,7 +205,7 @@ resources:
                 name:
                   get_param: ComputeProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -184,25 +227,25 @@ resources:
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond0
                 vlan_id:
                   get_param: TenantNetworkVlanID
                 mtu:
-                  get_param: TenantNetworkMTU
+                  get_param: TenantMtu
                 addresses:
                 - ip_netmask:
                     get_param: TenantIpSubnet
@@ -211,67 +254,69 @@ resources:
                 vlan_id:
                   get_param: InternalApiNetworkVlanID
                 mtu:
-                  get_param: InternalApiMTU
+                  get_param: InternalApiMtu
                 addresses:
                 - ip_netmask:
                     get_param: InternalApiIpSubnet
               - type: ovs_user_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 use_dhcp: false
                 members:
                 - type: ovs_dpdk_bond
-                  name: ovs_dpdk_bond10
+                  name: dpdkbond0
+                  rx_queue:
+                    get_param: NumDpdkInterfaceRxQueues
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   ovs_options:
                     get_param: BondInterfaceOvsOptions
                   members:
                   - type: ovs_dpdk_port
                     name: dpdk0
+                    mtu:
+                      get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface1
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk1
+                    mtu:
+                      get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface2
-                      mtu:
-                        get_param: DefaultBondMTU
               - type: linux_bond
                 name: bond1
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond1
                 vlan_id:
                   get_param: StorageNetworkVlanID
                 mtu:
-                  get_param: StorageNetworkMTU
+                  get_param: StorageMtu
                 addresses:
                 - ip_netmask:
                     get_param: StorageIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_7_port/nic_environment.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_7_port/nic_environment.yaml
@@ -22,30 +22,30 @@ parameter_defaults:
   # CHANGEME: Change the interface names in the following lines for the
   # controller nodes provisioning interface and to include in the controller
   # nodes bonds
-  ControllerProvisioningInterface: em3
-  ControllerBond0Interface1: em1
-  ControllerBond0Interface2: p3p1
-  ControllerBond1Interface1: em2
-  ControllerBond1Interface2: p3p2
+  ControllerProvisioningInterface: eno3
+  ControllerBond0Interface1: ens5f0
+  ControllerBond0Interface2: ens7f0
+  ControllerBond1Interface1: ens5f1
+  ControllerBond1Interface2: ens7f1
   # The bonding mode to use for controller nodes
   ControllerBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
   # CHANGEME: Change the interface names in the following lines for the
   # compute nodes provisioning interface and to include in the compute
   # nodes bonds
-  ComputeProvisioningInterface: em3
-  ComputeBond0Interface1: em1
-  ComputeBond0Interface2: p3p1
-  ComputeBond1Interface1: em2
-  ComputeBond1Interface2: p3p2
+  ComputeProvisioningInterface: eno3
+  ComputeBond0Interface1: ens5f0
+  ComputeBond0Interface2: ens3f0
+  ComputeBond1Interface1: ens5f1
+  ComputeBond1Interface2: ens3f1
   # The bonding mode to use for compute nodes
   ComputeBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
   # CHANGEME: Change the interface names in the following lines for the
   # compute nodes provisioning interface and to include in the compute
   # DPDK bonds
-  ComputeOvsDpdkInterface1: p2p1
-  ComputeOvsDpdkInterface2: p3p1
+  ComputeOvsDpdkInterface1: ens4f0
+  ComputeOvsDpdkInterface2: ens4f1
   # The DPDK bonding mode to use for compute nodes
   BondInterfaceOvsOptions: bond_mode=balance-tcp lacp=active
   HostNicDriver: mlx5_core
@@ -53,10 +53,10 @@ parameter_defaults:
   # CHANGEME: Change the interface names in the following lines for the
   # storage nodes provisioning interface and to include in the storage
   # nodes bonds
-  StorageProvisioningInterface: em3
-  StorageBond0Interface1: em1
-  StorageBond0Interface2: p2p1
-  StorageBond1Interface1: em2
-  StorageBond1Interface2: p2p2
+  StorageProvisioningInterface: eno3
+  StorageBond0Interface1: ens1f0
+  StorageBond0Interface2: ens2f0
+  StorageBond1Interface1: ens1f1
+  StorageBond1Interface2: ens2f1
   # The bonding mode to use for storage nodes
   StorageBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1

--- a/src/pilot/templates/nic-configs/ovs-dpdk_7_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_7_port/storage.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for storage nodes.
+  Bond and VLAN configuration for storage nodes. comment14_0: ' The values of the following parameters are overridden by the
+  entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,15 +55,45 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneNetCidr:
+    description: Control plane/provisioning network and mask
+    type: string
+    default: ''
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
+    default: ''
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -100,31 +131,37 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -145,7 +182,7 @@ resources:
                 name:
                   get_param: StorageProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -165,12 +202,12 @@ resources:
               - type: ovs_bridge
                 name: br-bond0
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -178,51 +215,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_8_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_8_port/controller.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for controller nodes.
+  Bond and VLAN configuration for controller nodes. comment14_0: ' The values of the following parameters are overridden by
+  the entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -104,35 +154,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -151,9 +207,9 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-tenant
-                use_dhcp: false
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                    get_param: ProvisioningMtu
+                use_dhcp: false
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -183,7 +239,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -191,19 +247,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -212,7 +268,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -221,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -231,32 +287,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_8_port/dellcompute_dpdk.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_8_port/dellcompute_dpdk.yaml
@@ -50,15 +50,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -117,35 +150,45 @@ parameters:
     default: mlx5_core
     description: DPDK driver for Mellanox
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  NumDpdkInterfaceRxQueues:
+    description: Number of Rx Queues required for DPDK bond or DPDK ports
+    default: 1
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -167,7 +210,7 @@ resources:
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -189,19 +232,19 @@ resources:
                   name:
                     get_param: ComputeBond0Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond0
                 vlan_id:
                   get_param: TenantNetworkVlanID
                 mtu:
-                  get_param: TenantNetworkMTU
+                  get_param: TenantMtu
                 addresses:
                 - ip_netmask:
                     get_param: TenantIpSubnet
@@ -210,87 +253,89 @@ resources:
                 vlan_id:
                   get_param: InternalApiNetworkVlanID
                 mtu:
-                  get_param: InternalApiMTU
+                  get_param: InternalApiMtu
                 addresses:
                 - ip_netmask:
                     get_param: InternalApiIpSubnet
               - type: ovs_user_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 use_dhcp: false
                 members:
                 - type: ovs_dpdk_bond
-                  name: ovs_dpdk_bond10
+                  name: dpdkbond0
+                  rx_queue:
+                    get_param: NumDpdkInterfaceRxQueues
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   ovs_options:
                     get_param: BondInterfaceOvsOptions
                   members:
                   - type: ovs_dpdk_port
                     name: dpdk0
+                    mtu:
+                        get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface1
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk1
+                    mtu:
+                        get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface2
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk2
+                    mtu:
+                        get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface3
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk3
+                    mtu:
+                        get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface4
-                      mtu:
-                        get_param: DefaultBondMTU
               - type: linux_bond
                 name: bond1
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond1
                 vlan_id:
                   get_param: StorageNetworkVlanID
                 mtu:
-                  get_param: StorageNetworkMTU
+                  get_param: StorageMtu
                 addresses:
                 - ip_netmask:
                     get_param: StorageIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_8_port/nic_environment.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_8_port/nic_environment.yaml
@@ -19,46 +19,39 @@ resource_registry:
 
 
 parameter_defaults:
-  # CHANGEME: Change the interface names in the following lines for the
-  # controller nodes provisioning interface and to include in the controller
-  # nodes bonds
-  #ControllerProvisioningInterface: em3
-  ControllerBond0Interface1: em1
-  ControllerBond0Interface2: p3p1
-  ControllerBond1Interface1: em2
-  ControllerBond1Interface2: p3p2
+  # CHANGEME: Change the interface names in the following lines
+  # to include in the controller nodes bonds
+  ControllerBond0Interface1: ens5f0
+  ControllerBond0Interface2: ens7f0
+  ControllerBond1Interface1: ens5f1
+  ControllerBond1Interface2: ens7f1
   # The bonding mode to use for controller nodes
   ControllerBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
-  # CHANGEME: Change the interface names in the following lines for the
-  # compute nodes provisioning interface and to include in the compute
-  # nodes bonds
-  #ComputeProvisioningInterface: em3
-  ComputeBond0Interface1: em1
-  ComputeBond0Interface2: p3p1
-  ComputeBond1Interface1: em2
-  ComputeBond1Interface2: p3p2
+  # CHANGEME: Change the interface names in the following lines
+  # to include in the compute nodes bonds
+  ComputeBond0Interface1: ens5f0
+  ComputeBond0Interface2: ens3f0
+  ComputeBond1Interface1: ens5f1
+  ComputeBond1Interface2: ens3f1
   # The bonding mode to use for compute nodes
   ComputeBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
-  # CHANGEME: Change the interface names in the following lines for the
-  # compute nodes provisioning interface and to include in the compute
-  # DPDK bonds
-  ComputeOvsDpdkInterface1: p2p1
-  ComputeOvsDpdkInterface2: p3p1
-  ComputeOvsDpdkInterface3: p2p2
-  ComputeOvsDpdkInterface4: p3p2
+  # CHANGEME: Change the interface names in the following lines 
+  # for the compute DPDK bonds
+  ComputeOvsDpdkInterface1: ens4f0
+  ComputeOvsDpdkInterface2: ens8f0
+  ComputeOvsDpdkInterface3: ens4f1
+  ComputeOvsDpdkInterface4: ens8f1
   # The DPDK bonding mode to use for compute nodes
   BondInterfaceOvsOptions: bond_mode=balance-tcp lacp=active
   HostNicDriver: mlx5_core
   
-  # CHANGEME: Change the interface names in the following lines for the
-  # storage nodes provisioning interface and to include in the storage
-  # nodes bonds
-  #StorageProvisioningInterface: em3
-  StorageBond0Interface1: em1
-  StorageBond0Interface2: p2p1
-  StorageBond1Interface1: em2
-  StorageBond1Interface2: p2p2
+  # CHANGEME: Change the interface names in the following lines
+  # to include in the storage nodes bonds
+  StorageBond0Interface1: ens1f0
+  StorageBond0Interface2: ens2f0
+  StorageBond1Interface1: ens1f1
+  StorageBond1Interface2: ens2f1
   # The bonding mode to use for storage nodes
   StorageBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1

--- a/src/pilot/templates/nic-configs/ovs-dpdk_8_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_8_port/storage.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for storage nodes.
+  Bond and VLAN configuration for storage nodes. comment14_0: ' The values of the following parameters are overridden by the
+  entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,15 +55,40 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -96,31 +122,37 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -139,11 +171,11 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-bond0
-                mtu:
-                  get_param: ProvisioningNetworkMTU
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
+                mtu:
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -161,7 +193,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -169,51 +201,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_9_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_9_port/controller.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for controller nodes.
+  Bond and VLAN configuration for controller nodes. comment14_0: ' The values of the following parameters are overridden by
+  the entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -108,35 +158,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -158,7 +214,7 @@ resources:
                   get_param: ControllerProvisioningInterface
                 use_dhcp: false
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -187,12 +243,12 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -200,19 +256,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -221,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -230,7 +286,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -240,32 +296,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_9_port/dellcompute_dpdk.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_9_port/dellcompute_dpdk.yaml
@@ -50,15 +50,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -121,35 +154,45 @@ parameters:
     default: mlx5_core
     description: DPDK driver for Mellanox
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  NumDpdkInterfaceRxQueues:
+    description: Number of Rx Queues required for DPDK bond or DPDK ports
+    default: 1
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -170,7 +213,7 @@ resources:
                 name:
                   get_param: ComputeProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -192,25 +235,25 @@ resources:
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond0
                 vlan_id:
                   get_param: TenantNetworkVlanID
                 mtu:
-                  get_param: TenantNetworkMTU
+                  get_param: TenantMtu
                 addresses:
                 - ip_netmask:
                     get_param: TenantIpSubnet
@@ -219,87 +262,89 @@ resources:
                 vlan_id:
                   get_param: InternalApiNetworkVlanID
                 mtu:
-                  get_param: InternalApiMTU
+                  get_param: InternalApiMtu
                 addresses:
                 - ip_netmask:
                     get_param: InternalApiIpSubnet
               - type: ovs_user_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 use_dhcp: false
                 members:
                 - type: ovs_dpdk_bond
-                  name: ovs_dpdk_bond10
+                  name: dpdkbond0
+                  rx_queue:
+                    get_param: NumDpdkInterfaceRxQueues
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   ovs_options:
                     get_param: BondInterfaceOvsOptions
                   members:
                   - type: ovs_dpdk_port
                     name: dpdk0
+                    mtu:
+                      get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface1
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk1
+                    mtu:
+                      get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface2
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk2
+                    mtu:
+                      get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface3
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk3
+                    mtu:
+                      get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface4
-                      mtu:
-                        get_param: DefaultBondMTU
               - type: linux_bond
                 name: bond1
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond1
                 vlan_id:
                   get_param: StorageNetworkVlanID
                 mtu:
-                  get_param: StorageNetworkMTU
+                  get_param: StorageMtu
                 addresses:
                 - ip_netmask:
                     get_param: StorageIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_9_port/nic_environment.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_9_port/nic_environment.yaml
@@ -22,32 +22,32 @@ parameter_defaults:
   # CHANGEME: Change the interface names in the following lines for the
   # controller nodes provisioning interface and to include in the controller
   # nodes bonds
-  ControllerProvisioningInterface: em3
-  ControllerBond0Interface1: em1
-  ControllerBond0Interface2: p3p1
-  ControllerBond1Interface1: em2
-  ControllerBond1Interface2: p3p2
+  ControllerProvisioningInterface: eno3
+  ControllerBond0Interface1: ens5f0
+  ControllerBond0Interface2: ens7f0
+  ControllerBond1Interface1: ens5f1
+  ControllerBond1Interface2: ens7f1
   # The bonding mode to use for controller nodes
   ControllerBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
   # CHANGEME: Change the interface names in the following lines for the
   # compute nodes provisioning interface and to include in the compute
   # nodes bonds
-  ComputeProvisioningInterface: em3
-  ComputeBond0Interface1: em1
-  ComputeBond0Interface2: p3p1
-  ComputeBond1Interface1: em2
-  ComputeBond1Interface2: p3p2
+  ComputeProvisioningInterface: eno3
+  ComputeBond0Interface1: ens5f0
+  ComputeBond0Interface2: ens3f0
+  ComputeBond1Interface1: ens5f1
+  ComputeBond1Interface2: ens3f1
   # The bonding mode to use for compute nodes
   ComputeBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
   # CHANGEME: Change the interface names in the following lines for the
   # compute nodes provisioning interface and to include in the compute
   # DPDK bonds
-  ComputeOvsDpdkInterface1: p2p1
-  ComputeOvsDpdkInterface2: p3p1
-  ComputeOvsDpdkInterface3: p2p2
-  ComputeOvsDpdkInterface4: p3p2
+  ComputeOvsDpdkInterface1: ens4f0
+  ComputeOvsDpdkInterface2: ens8f0
+  ComputeOvsDpdkInterface3: ens4f1
+  ComputeOvsDpdkInterface4: ens8f1
   # The DPDK bonding mode to use for compute nodes
   BondInterfaceOvsOptions: bond_mode=balance-tcp lacp=active
   HostNicDriver: mlx5_core
@@ -55,10 +55,10 @@ parameter_defaults:
   # CHANGEME: Change the interface names in the following lines for the
   # storage nodes provisioning interface and to include in the storage
   # nodes bonds
-  StorageProvisioningInterface: em3
-  StorageBond0Interface1: em1
-  StorageBond0Interface2: p2p1
-  StorageBond1Interface1: em2
-  StorageBond1Interface2: p2p2
+  StorageProvisioningInterface: eno3
+  StorageBond0Interface1: ens1f0
+  StorageBond0Interface2: ens2f0
+  StorageBond1Interface1: ens1f1
+  StorageBond1Interface2: ens2f1
   # The bonding mode to use for storage nodes
   StorageBondInterfaceOptions: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1

--- a/src/pilot/templates/nic-configs/ovs-dpdk_9_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_9_port/storage.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for storage nodes.
+  Bond and VLAN configuration for storage nodes. comment14_0: ' The values of the following parameters are overridden by the
+  entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,15 +55,45 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneNetCidr:
+    description: Control plane/provisioning network and mask
+    type: string
+    default: ''
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
+    default: ''
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -100,31 +131,37 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -145,7 +182,7 @@ resources:
                 name:
                   get_param: StorageProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -165,12 +202,12 @@ resources:
               - type: ovs_bridge
                 name: br-bond0
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -178,51 +215,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_sriov_8_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_sriov_8_port/controller.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for controller nodes.
+  Bond and VLAN configuration for controller nodes. comment14_0: ' The values of the following parameters are overridden by
+  the entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -104,35 +154,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -152,7 +208,7 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                    get_param: ProvisioningMtu
                 use_dhcp: false
                 addresses:
                 - ip_netmask:
@@ -183,7 +239,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -191,19 +247,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -212,7 +268,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -221,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -231,32 +287,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_sriov_8_port/dellcompute_dpdk_sriov.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_sriov_8_port/dellcompute_dpdk_sriov.yaml
@@ -50,15 +50,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -100,6 +133,11 @@ parameters:
     default: p3p1
     description: Dpdk Interface 2 name
     type: string
+  BondInterfaceOvsOptions:
+    default: bond_mode=balance-tcp lacp=active
+    description: The bonding_options string for the bond interface. Set things like 'bond_mode=balance-tcp lacp=active' using
+      this option.
+    type: string
   ComputeSriovInterface1:
     default: p2p1
     description: SRIOV Interface 1 name
@@ -108,44 +146,53 @@ parameters:
     default: p3p1
     description: SRIOV Interface 2 name
     type: string
-  BondInterfaceOvsOptions:
-    default: bond_mode=balance-tcp lacp=active
-    description: The bonding_options string for the bond interface. Set things like 'bond_mode=balance-tcp lacp=active' using
-      this option.
-    type: string
+  NumSriovVfs: # Override this via parameter_defaults
+    default: 4
+    description: Number of SRIOV Virtual Functions.
+    type: number
   HostNicDriver: # Override this via parameter_defaults
     default: mlx5_core
     description: DPDK driver for Mellanox
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  NumDpdkInterfaceRxQueues:
+    description: Number of Rx Queues required for DPDK bond or DPDK ports
+    default: 1
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -167,7 +214,7 @@ resources:
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -189,19 +236,19 @@ resources:
                   name:
                     get_param: ComputeBond0Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond0
                 vlan_id:
                   get_param: TenantNetworkVlanID
                 mtu:
-                  get_param: TenantNetworkMTU
+                  get_param: TenantMtu
                 addresses:
                 - ip_netmask:
                     get_param: TenantIpSubnet
@@ -210,82 +257,96 @@ resources:
                 vlan_id:
                   get_param: InternalApiNetworkVlanID
                 mtu:
-                  get_param: InternalApiMTU
+                  get_param: InternalApiMtu
                 addresses:
                 - ip_netmask:
                     get_param: InternalApiIpSubnet
               - type: ovs_user_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 use_dhcp: false
                 members:
                 - type: ovs_dpdk_bond
-                  name: ovs_dpdk_bond10
+                  name: dpdkbond0
+                  rx_queue:
+                    get_param: NumDpdkInterfaceRxQueues
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   ovs_options:
                     get_param: BondInterfaceOvsOptions
                   members:
                   - type: ovs_dpdk_port
                     name: dpdk0
+                    mtu:
+                        get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface1
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk1
+                    mtu:
+                        get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface2
-                      mtu:
-                        get_param: DefaultBondMTU
               - type: linux_bond
                 name: bond1
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond1
                 vlan_id:
                   get_param: StorageNetworkVlanID
                 mtu:
-                  get_param: StorageNetworkMTU
+                  get_param: StorageMtu
                 addresses:
                 - ip_netmask:
                     get_param: StorageIpSubnet
-              - type: interface
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
-              - type: interface
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface2
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/ovs-dpdk_sriov_8_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_sriov_8_port/storage.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for storage nodes.
+  Bond and VLAN configuration for storage nodes. comment14_0: ' The values of the following parameters are overridden by the
+  entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,15 +55,40 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -96,31 +122,37 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -139,11 +171,11 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-bond0
-                mtu:
-                  get_param: ProvisioningNetworkMTU
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
+                mtu:
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -161,7 +193,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -169,51 +201,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_sriov_9_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_sriov_9_port/controller.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for controller nodes.
+  Bond and VLAN configuration for controller nodes. comment14_0: ' The values of the following parameters are overridden by
+  the entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -108,35 +158,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -156,9 +212,9 @@ resources:
               - type: interface
                 name:
                   get_param: ControllerProvisioningInterface
-                mtu:
-                  get_param: ProvisioningNetworkMTU
                 use_dhcp: false
+                mtu:
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -187,12 +243,12 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -200,19 +256,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -221,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -230,7 +286,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -240,32 +296,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/ovs-dpdk_sriov_9_port/dellcompute_dpdk_sriov.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_sriov_9_port/dellcompute_dpdk_sriov.yaml
@@ -50,15 +50,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -104,6 +137,11 @@ parameters:
     default: p3p1
     description: Dpdk Interface 2 name
     type: string
+  BondInterfaceOvsOptions:
+    default: bond_mode=balance-tcp lacp=active
+    description: The bonding_options string for the bond interface. Set things like 'bond_mode=balance-tcp lacp=active' using
+      this option.
+    type: string
   ComputeSriovInterface1:
     default: p2p1
     description: SRIOV Interface 1 name
@@ -112,44 +150,53 @@ parameters:
     default: p3p1
     description: SRIOV Interface 2 name
     type: string
-  BondInterfaceOvsOptions:
-    default: bond_mode=balance-tcp lacp=active
-    description: The bonding_options string for the bond interface. Set things like 'bond_mode=balance-tcp lacp=active' using
-      this option.
-    type: string
+  NumSriovVfs: # Override this via parameter_defaults
+    default: 4
+    description: Number of SRIOV Virtual Functions.
+    type: number
   HostNicDriver: # Override this via parameter_defaults
     default: mlx5_core
     description: DPDK driver for Mellanox
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  NumDpdkInterfaceRxQueues:
+    description: Number of Rx Queues required for DPDK bond or DPDK ports
+    default: 1
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -170,7 +217,7 @@ resources:
                 name:
                   get_param: ComputeProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -192,25 +239,25 @@ resources:
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond0Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond0
                 vlan_id:
                   get_param: TenantNetworkVlanID
                 mtu:
-                  get_param: TenantNetworkMTU
+                  get_param: TenantMtu
                 addresses:
                 - ip_netmask:
                     get_param: TenantIpSubnet
@@ -219,82 +266,97 @@ resources:
                 vlan_id:
                   get_param: InternalApiNetworkVlanID
                 mtu:
-                  get_param: InternalApiMTU
+                  get_param: InternalApiMtu
                 addresses:
                 - ip_netmask:
                     get_param: InternalApiIpSubnet
               - type: ovs_user_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 use_dhcp: false
                 members:
                 - type: ovs_dpdk_bond
-                  name: ovs_dpdk_bond10
+                  name: dpdkbond0
+                  rx_queue:
+                    get_param: NumDpdkInterfaceRxQueues
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   ovs_options:
                     get_param: BondInterfaceOvsOptions
                   members:
                   - type: ovs_dpdk_port
                     name: dpdk0
+                    mtu:
+                      get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface1
-                      mtu:
-                        get_param: DefaultBondMTU
                   - type: ovs_dpdk_port
                     name: dpdk1
+                    mtu:
+                      get_param: DefaultBondMtu
                     driver:
                         get_param: HostNicDriver
                     members:
                     - type: interface
                       name:
                         get_param: ComputeOvsDpdkInterface2
-                      mtu:
-                        get_param: DefaultBondMTU
               - type: linux_bond
                 name: bond1
                 bonding_options:
                   get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface1
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   primary: true
                 - type: interface
                   name:
                     get_param: ComputeBond1Interface2
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
               - type: vlan
                 device: bond1
                 vlan_id:
                   get_param: StorageNetworkVlanID
                 mtu:
-                  get_param: StorageNetworkMTU
+                  get_param: StorageMtu
                 addresses:
                 - ip_netmask:
                     get_param: StorageIpSubnet
-              - type: interface
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
-              - type: interface
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface2
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/ovs-dpdk_sriov_9_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/ovs-dpdk_sriov_9_port/storage.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for storage nodes.
+  Bond and VLAN configuration for storage nodes. comment14_0: ' The values of the following parameters are overridden by the
+  entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,15 +55,45 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneNetCidr:
+    description: Control plane/provisioning network and mask
+    type: string
+    default: ''
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
+    default: ''
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -100,31 +131,37 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -145,7 +182,7 @@ resources:
                 name:
                   get_param: StorageProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -165,12 +202,12 @@ resources:
               - type: ovs_bridge
                 name: br-bond0
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -178,51 +215,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/sriov_6_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/sriov_6_port/controller.yaml
@@ -55,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -105,35 +154,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -152,9 +207,9 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-tenant
-                use_dhcp: false
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                    get_param: ProvisioningMtu
+                use_dhcp: false
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -184,7 +239,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -192,19 +247,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -213,7 +268,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -222,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -232,32 +287,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/sriov_6_port/dellcompute_sriov.yaml
+++ b/src/pilot/templates/nic-configs/sriov_6_port/dellcompute_sriov.yaml
@@ -51,15 +51,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -101,38 +134,49 @@ parameters:
     default: p3p1
     description: SRIOV Interface 2 name
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  NumSriovVfs: # Override this via parameter_defaults
+    default: 4
+    description: Number of SRIOV Virtual Functions.
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -147,9 +191,9 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-tenant
-                mtu:
-                  get_param: ProvisioningNetworkMTU
                 use_dhcp: false
+                mtu:
+                  get_param: ProvisioningMtu
                 dns_servers:
                   get_param: DnsServers
                 addresses:
@@ -171,25 +215,25 @@ resources:
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -198,54 +242,68 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
-              - type: interface
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
-              - type: interface
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface2
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+
+
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/sriov_6_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/sriov_6_port/storage.yaml
@@ -55,15 +55,40 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -97,34 +122,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -139,11 +171,11 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-bond0
-                mtu:
-                  get_param: ProvisioningNetworkMTU
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
+                mtu:
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -161,7 +193,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -169,51 +201,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/sriov_7_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/sriov_7_port/controller.yaml
@@ -55,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -109,35 +158,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -159,7 +214,7 @@ resources:
                   get_param: ControllerProvisioningInterface
                 use_dhcp: false
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -188,12 +243,12 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -201,19 +256,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -222,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -231,7 +286,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -241,32 +296,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/sriov_7_port/dellcompute_sriov.yaml
+++ b/src/pilot/templates/nic-configs/sriov_7_port/dellcompute_sriov.yaml
@@ -51,15 +51,53 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneNetCidr:
+    description: Control plane/provisioning network and mask
+    type: string
+    default: ''
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
+    default: ''
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -105,38 +143,49 @@ parameters:
     default: p3p1
     description: SRIOV Interface 2 name
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  NumSriovVfs: # Override this via parameter_defaults
+    default: 4
+    description: Number of SRIOV Virtual Functions.
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -153,7 +202,7 @@ resources:
                 name:
                   get_param: ComputeProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -173,32 +222,32 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -207,54 +256,67 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
-              - type: interface
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
-              - type: interface
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface2
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/sriov_7_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/sriov_7_port/storage.yaml
@@ -55,15 +55,45 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneNetCidr:
+    description: Control plane/provisioning network and mask
+    type: string
+    default: ''
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
+    default: ''
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -101,34 +131,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -145,7 +182,7 @@ resources:
                 name:
                   get_param: StorageProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -165,12 +202,12 @@ resources:
               - type: ovs_bridge
                 name: br-bond0
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -178,51 +215,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/sriov_8_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/sriov_8_port/controller.yaml
@@ -55,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -105,38 +154,45 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -151,9 +207,9 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-tenant
-                use_dhcp: false
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                    get_param: ProvisioningMtu
+                use_dhcp: false
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -183,7 +239,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -191,19 +247,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -212,7 +268,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -221,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -231,32 +287,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/sriov_8_port/dellcompute_sriov.yaml
+++ b/src/pilot/templates/nic-configs/sriov_8_port/dellcompute_sriov.yaml
@@ -51,15 +51,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -109,38 +142,49 @@ parameters:
     default: p3p2
     description: SRIOV Interface 4 name
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  NumSriovVfs: # Override this via parameter_defaults
+    default: 4
+    description: Number of SRIOV Virtual Functions.
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -155,9 +199,9 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-tenant
-                mtu:
-                  get_param: ProvisioningNetworkMTU
                 use_dhcp: false
+                mtu:
+                  get_param: ProvisioningMtu
                 dns_servers:
                   get_param: DnsServers
                 addresses:
@@ -179,25 +223,25 @@ resources:
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -206,66 +250,91 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
-                      get_param: StorageIpSubnet
-              - type: interface
+                      get_param: StorageIpSubnet                       
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
-              - type: interface
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface2
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
-              - type: interface
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface3
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
-              - type: interface
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface4
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+                
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/sriov_8_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/sriov_8_port/storage.yaml
@@ -55,15 +55,40 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -97,34 +122,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -139,11 +171,11 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-bond0
-                mtu:
-                  get_param: ProvisioningNetworkMTU
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
+                mtu:
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -161,7 +193,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -169,51 +201,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/sriov_9_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/sriov_9_port/controller.yaml
@@ -55,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -109,38 +158,45 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -158,7 +214,7 @@ resources:
                   get_param: ControllerProvisioningInterface
                 use_dhcp: false
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -187,12 +243,12 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -200,19 +256,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -221,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -230,7 +286,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -240,32 +296,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/sriov_9_port/dellcompute_sriov.yaml
+++ b/src/pilot/templates/nic-configs/sriov_9_port/dellcompute_sriov.yaml
@@ -51,15 +51,53 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneNetCidr:
+    description: Control plane/provisioning network and mask
+    type: string
+    default: ''
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
+    default: ''
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -113,38 +151,49 @@ parameters:
     default: p3p2
     description: SRIOV Interface 4 name
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  NumSriovVfs: # Override this via parameter_defaults
+    default: 4
+    description: Number of SRIOV Virtual Functions.
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -161,7 +210,7 @@ resources:
                 name:
                   get_param: ComputeProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -181,32 +230,32 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -215,66 +264,91 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
-              - type: interface
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
-              - type: interface
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface2
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
-              - type: interface
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface3
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
-              - type: interface
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+              - type: sriov_pf
                 name:
                   get_param: ComputeSriovInterface4
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
+                numvfs:
+                      get_param: NumSriovVfs
                 use_dhcp: false
+                defroute: false
+                nm_controlled: true
+                hotplug: true
+                promisc: false
+                
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/sriov_9_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/sriov_9_port/storage.yaml
@@ -55,15 +55,45 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneNetCidr:
+    description: Control plane/provisioning network and mask
+    type: string
+    default: ''
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
+    default: ''
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -101,34 +131,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -145,7 +182,7 @@ resources:
                 name:
                   get_param: StorageProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -165,12 +202,12 @@ resources:
               - type: ovs_bridge
                 name: br-bond0
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -178,51 +215,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/ovs-hw-offload.yaml
+++ b/src/pilot/templates/ovs-hw-offload.yaml
@@ -7,7 +7,7 @@ resource_registry:
 
 parameter_defaults:
 
-  NovaSchedulerDefaultFilters: ['RetryFilter','AvailabilityZoneFilter','RamFilter','ComputeFilter','ComputeCapabilitiesFilter','ImagePropertiesFilter','ServerGroupAntiAffinityFilter','ServerGroupAffinityFilter','PciPassthroughFilter']
+  NovaSchedulerDefaultFilters: ['RetryFilter','AvailabilityZoneFilter','ComputeFilter','ComputeCapabilitiesFilter','ImagePropertiesFilter','ServerGroupAntiAffinityFilter','ServerGroupAffinityFilter','PciPassthroughFilter','NUMATopologyFilter']
   NovaSchedulerAvailableFilters: ["nova.scheduler.filters.all_filters","nova.scheduler.filters.pci_passthrough_filter.PciPassthroughFilter"]
 
   # Kernel arguments for ComputeSriov node

--- a/src/pilot/templates/roles_data.yaml
+++ b/src/pilot/templates/roles_data.yaml
@@ -79,6 +79,8 @@
     - OS::TripleO::Services::CinderBackendDellEMCVMAXISCSI
     - OS::TripleO::Services::CinderBackendDellEMCVNX
     - OS::TripleO::Services::CinderBackendDellEMCXTREMIOISCSI
+    - OS::TripleO::Services::CinderBackendDellEMCVxFlexOS
+    - OS::TripleO::Services::CinderBackendDellEMCXtremio
     - OS::TripleO::Services::CinderBackendNetApp
     - OS::TripleO::Services::CinderBackendPure
     - OS::TripleO::Services::CinderBackendScaleIO
@@ -345,6 +347,8 @@
     - OS::TripleO::Services::NeutronBgpVpnBagpipe
     - OS::TripleO::Services::NeutronLinuxbridgeAgent
     - OS::TripleO::Services::NeutronVppAgent
+    - OS::TripleO::Services::NeutronSriovAgent
+    - OS::TripleO::Services::NeutronSriovHostConfig
     - OS::TripleO::Services::NovaAZConfig
     - OS::TripleO::Services::NovaCompute
     - OS::TripleO::Services::NovaLibvirt
@@ -353,6 +357,7 @@
     - OS::TripleO::Services::ContainersLogrotateCrond
     - OS::TripleO::Services::Podman
     - OS::TripleO::Services::Rear
+    - OS::TripleO::Services::OvsDpdkNetcontrold
     - OS::TripleO::Services::Rhsm
     - OS::TripleO::Services::Rsyslog
     - OS::TripleO::Services::RsyslogSidecar
@@ -365,11 +370,9 @@
     - OS::TripleO::Services::TripleoPackages
     - OS::TripleO::Services::Tuned
     - OS::TripleO::Services::Vpp
+    - OS::TripleO::Services::Ptp
     - OS::TripleO::Services::OVNController
     - OS::TripleO::Services::OVNMetadataAgent
-    - OS::TripleO::Services::NeutronSriovAgent
-    - OS::TripleO::Services::NeutronSriovHostConfig
-
 ###############################################################################
 #
 ###############################################################################

--- a/src/pilot/templates/unity-manila-config.yaml
+++ b/src/pilot/templates/unity-manila-config.yaml
@@ -10,11 +10,11 @@ parameter_defaults:
   ManilaUnityBackendName: tripleo_manila_unity
 # DELL-NFV Overrides
   ManilaUnityDriverHandlesShareServers: <manila_unity_driver_handles_share_servers>
-  ManilaUnityNasLogin: <manila_unity_nas_login>
-  ManilaUnityNasPassword: <manila_unity_nas_password>
-  ManilaUnityNasServer: <manila_unity_nas_server>
-  ManilaUnityServerMetaPool: <manila_unity_server_meta_pool>
-  ManilaUnityShareDataPools: <manila_unity_share_data_pools>
-  ManilaUnityEthernetPorts: <manila_unity_ethernet_ports>
+  ManilaUnityNasLogin: '<manila_unity_nas_login>'
+  ManilaUnityNasPassword: '<manila_unity_nas_password>'
+  ManilaUnityNasServer: '<manila_unity_nas_server>'
+  ManilaUnityServerMetaPool: '<manila_unity_server_meta_pool>'
+  ManilaUnityShareDataPools: '<manila_unity_share_data_pools>'
+  ManilaUnityEthernetPorts: '<manila_unity_ethernet_ports>'
   ManilaUnityEmcSslCertVerify: <manila_unity_ssl_cert_verify>
-  ManilaUnityEmcSslCertPath: <manila_unity_ssl_cert_path>
+  ManilaUnityEmcSslCertPath: '<manila_unity_ssl_cert_path>'

--- a/src/pilot/templates/unity-manila-container.yaml
+++ b/src/pilot/templates/unity-manila-container.yaml
@@ -1,0 +1,2 @@
+parameter_defaults:
+  ContainerManilaShareImage: <dellemc_container_registry_domain>/dellemc/openstack-manila-share-dellemc-rhosp16:16.1-1


### PR DESCRIPTION
This synchronizes branch `experimental-upstream-ironic-JS-16.1-00` with branch `JS-16.1`. All commits on `JS-16.1` are available on `experimental-upstream-ironic-16.1-00`.

The SHAs of the commits this adds to `experimental-upstream-ironic-JS-16.1-00` are identical to those on `JS-16.1`. That will later make it easier to merge `experimental-upstream-ironic-JS-16.1-00` into `JS-16.1`.