### PR TITLE
DVR parameter override fix 

### DIFF
--- a/src/pilot/deploy-overcloud.py
+++ b/src/pilot/deploy-overcloud.py
@@ -524,11 +524,6 @@ def main():
         if args.static_vips:
             env_opts += " -e ~/pilot/templates/static-vip-environment.yaml"
 
-        # The neutron-ovs-dvr.yaml.yaml must be included after the
-        # network-environment.yaml
-        if args.dvr_enable:
-            env_opts += " -e ~/pilot/templates/neutron-ovs-dvr.yaml"
-
         # The configure-barbican.yaml must be included after the
         # network-environment.yaml
         if args.barbican_enable:
@@ -548,6 +543,11 @@ def main():
         # in OSP16.1. In case we need to use OVN in future, please delete this line
         env_opts += " -e ~/pilot/templates/overcloud/environments/services/neutron-ovs.yaml"
         
+        # The neutron-ovs-dvr.yaml.yaml must be included after the
+        # neutron-ovs.yaml
+        if args.dvr_enable:
+            env_opts += " -e ~/pilot/templates/neutron-ovs-dvr.yaml"
+
         # The dell-environment.yaml must be included after the
         # storage-environment.yaml and ceph-radosgw.yaml
         env_opts += " -e ~/pilot/templates/overcloud/environments/" \

--- a/src/pilot/templates/neutron-ovs-dvr.yaml
+++ b/src/pilot/templates/neutron-ovs-dvr.yaml
@@ -13,8 +13,9 @@
 # limitations under the License.
 
 resource_registry:
-  OS::TripleO::Services::ComputeNeutronL3Agent: ./overcloud/docker/services/neutron-l3.yaml
-  OS::TripleO::Services::ComputeNeutronMetadataAgent: ./overcloud/docker/services/neutron-metadata.yaml
+  OS::TripleO::Services::ComputeNeutronL3Agent: ./overcloud/deployment/neutron/neutron-l3-container-puppet.yaml
+  OS::TripleO::Services::ComputeNeutronMetadataAgent: ./overcloud/deployment/neutron/neutron-metadata-container-puppet.yaml
+#  OS::TripleO::DellCompute::Net::SoftwareConfig: ./overcloud/net-config-bridge.yaml
 
 parameter_defaults:
 

--- a/src/pilot/templates/nic-configs/dvr_6_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/dvr_6_port/controller.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for controller nodes.
+  Bond and VLAN configuration for controller nodes. comment14_0: ' The values of the following parameters are overridden by
+  the entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -82,15 +132,14 @@ parameters:
     type: string
   ProvisioningNetworkGateway:
     default: 192.168.120.1
-    description: The IP of the gateway on the provisioning network which will
-                 allow access to the management network.
+    description: The IP of the gateway on the provisioning network which will allow access to the management network.
     type: string
   ControllerBond0Interface1:
     default: em1
     description: Bond 0 interface 1 name
     type: string
   ControllerBond0Interface2:
-    default: p1p1
+    default: p3p1
     description: Bond 0 interface 2 name
     type: string
   ControllerBond1Interface1:
@@ -98,42 +147,48 @@ parameters:
     description: Bond 1 interface 1 name
     type: string
   ControllerBond1Interface2:
-    default: p1p2
+    default: p3p2
     description: Bond 1 interface 2 name
     type: string
   ControllerBondInterfaceOptions:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -153,7 +208,7 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                    get_param: ProvisioningNetworkMTU
+                    get_param: ProvisioningMtu
                 use_dhcp: false
                 addresses:
                 - ip_netmask:
@@ -184,7 +239,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -192,19 +247,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -213,7 +268,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -222,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -232,32 +287,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/dvr_6_port/dellcompute.yaml
+++ b/src/pilot/templates/nic-configs/dvr_6_port/dellcompute.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for compute nodes.
+  Bond and VLAN configuration for compute nodes. comment14_0: ' The values of the following parameters are overridden by the
+  entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -50,15 +51,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -77,7 +111,7 @@ parameters:
     description: Bond 0 interface 1 name
     type: string
   ComputeBond0Interface2:
-    default: p3p2
+    default: p3p1
     description: Bond 0 interface 2 name
     type: string
   ComputeBond1Interface1:
@@ -85,7 +119,7 @@ parameters:
     description: Bond 1 interface 1 name
     type: string
   ComputeBond1Interface2:
-    default: p1p1
+    default: p3p2
     description: Bond 1 interface 2 name
     type: string
   ComputeBond2Interface1:
@@ -100,38 +134,45 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
+    default: 1500
+    description: MTU value for this network.
+    type: number
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
-    default: 1500
-    description: MTU value for this network.
-    type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -148,7 +189,7 @@ resources:
                 name: br-tenant
                 use_dhcp: false
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 dns_servers:
                   get_param: DnsServers
                 addresses:
@@ -170,25 +211,25 @@ resources:
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -202,32 +243,32 @@ resources:
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -235,27 +276,26 @@ resources:
                 name:
                   bridge_name
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond2
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond2Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond2Interface2
                     mtu:
-                      get_param: DefaultBondMTU
-
+                      get_param: DefaultBondMtu
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/dvr_6_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/dvr_6_port/storage.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for storage nodes.
+  Bond and VLAN configuration for storage nodes. comment14_0: ' The values of the following parameters are overridden by the
+  entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -54,15 +55,40 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -81,7 +107,7 @@ parameters:
     description: Bond 0 interface 1 name
     type: string
   StorageBond0Interface2:
-    default: p4p1
+    default: p2p1
     description: Bond 0 interface 2 name
     type: string
   StorageBond1Interface1:
@@ -89,41 +115,48 @@ parameters:
     description: Bond 1 interface 1 name
     type: string
   StorageBond1Interface2:
-    default: p4p2
+    default: p2p2
     description: Bond 1 interface 2 name
     type: string
   StorageBondInterfaceOptions:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -142,7 +175,7 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -159,60 +192,60 @@ resources:
                 members:
                 - type: linux_bond
                   name: bond0
+                  mtu:
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
-                  mtu:
-                    get_param: DefaultBondMTU
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/dvr_7_port/controller.yaml
+++ b/src/pilot/templates/nic-configs/dvr_7_port/controller.yaml
@@ -55,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -109,35 +158,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -159,7 +214,7 @@ resources:
                   get_param: ControllerProvisioningInterface
                 use_dhcp: false
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -188,12 +243,12 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -201,19 +256,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -222,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -231,7 +286,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -241,32 +296,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet

--- a/src/pilot/templates/nic-configs/dvr_7_port/dellcompute.yaml
+++ b/src/pilot/templates/nic-configs/dvr_7_port/dellcompute.yaml
@@ -1,6 +1,7 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for compute nodes.
+  Bond and VLAN configuration for compute nodes. comment14_0: ' The values of the following parameters are overridden by the
+  entries in' comment15_0: ' network-environment.yaml'
 parameters:
   ControlPlaneIp:
     default: ''
@@ -50,15 +51,53 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneNetCidr:
+    description: Control plane/provisioning network and mask
+    type: string
+    default: ''
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
+    default: ''
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -81,7 +120,7 @@ parameters:
     description: Bond 0 interface 1 name
     type: string
   ComputeBond0Interface2:
-    default: p3p2
+    default: p3p1
     description: Bond 0 interface 2 name
     type: string
   ComputeBond1Interface1:
@@ -89,7 +128,7 @@ parameters:
     description: Bond 1 interface 1 name
     type: string
   ComputeBond1Interface2:
-    default: p1p1
+    default: p3p2
     description: Bond 1 interface 2 name
     type: string
   ComputeBond2Interface1:
@@ -104,35 +143,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -153,7 +198,7 @@ resources:
                 name:
                   get_param: ComputeProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -173,32 +218,32 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -207,39 +252,39 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -247,27 +292,26 @@ resources:
                 name:
                   bridge_name
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond2
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond2Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond2Interface2
                     mtu:
-                      get_param: DefaultBondMTU
-
+                      get_param: DefaultBondMtu
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/dvr_7_port/storage.yaml
+++ b/src/pilot/templates/nic-configs/dvr_7_port/storage.yaml
@@ -55,15 +55,45 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneNetCidr:
+    description: Control plane/provisioning network and mask
+    type: string
+    default: ''
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
+    default: ''
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -101,31 +131,37 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
@@ -146,7 +182,7 @@ resources:
                 name:
                   get_param: StorageProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -166,12 +202,12 @@ resources:
               - type: ovs_bridge
                 name: br-bond0
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -179,51 +215,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet


### PR DESCRIPTION
Forgot to include the re-ordering of DVR template in previous DVR pull request. This will override neutron-ovs.yaml parameters to deploy DVR.