### PR TITLE
SRIOV-Offload support, updates and templates

### DIFF
--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -232,7 +232,7 @@ class Director(InfraHost):
             cmd = '~/pilot/install-director.sh --dns ' + \
                   self.settings.name_server + \
                   " --director_ip " + \
-                  self.ip 
+                  self.ip
 
         if len(self.settings.overcloud_nodes_pwd) > 0:
             cmd += " --nodes_pwd " + self.settings.overcloud_nodes_pwd
@@ -1543,27 +1543,16 @@ class Director(InfraHost):
         # Specify number of VFs for sriov mentioned interfaces
         sriov_map_setting = []
         sriov_pci_passthrough = []
-        physical_network = ["physint", "physint1", "physint2", "physint3"]
+        physical_network = "physint"
         check = 0
         for interface in sriov_interfaces:
-            devname = interface
-            if (self.settings.enable_smart_nic is True):
-                mapping = physical_network[check] + ':' + interface
-                nova_pci = '{devname: ' + \
-                           '"' + interface + '",' + \
-                           'physical_network: ' + \
-                           '"' + physical_network[check] + '"}'
-                check = check + 1
-
-            else:
-                mapping = physical_network[0] + ':' + interface
-                nova_pci = '{devname: ' + \
-                           '"' + interface + '",' + \
-                           'physical_network: ' + \
-                           '"' + physical_network[0] + '"}'
+            mapping = physical_network + ':' + interface
+            nova_pci = '{devname: ' + \
+                       '"' + interface + '",' + \
+                       'physical_network: ' + \
+                       '"' + physical_network + '"}'
 
             sriov_map_setting.append(mapping)
-
             sriov_pci_passthrough.append(nova_pci)
 
         sriov_map_setting = "'" + ",".join(sriov_map_setting) + "'"

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -239,23 +239,19 @@ StorageBondInterfaceOptions=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 la
 #ComputeOvsDpdkInterface4=p3p2
 #BondInterfaceOvsOptions=bond_mode=balance-tcp lacp=active
 
-# To enable standalone SR-IOV, two or four interfaces should be used.
+# To enable standalone SR-IOV, two or four interfaces should be used without bonding options.
 # For two interfaces, uncomment 'ComputeSriovInterface1' and 'ComputeSriovInterface2'.
 # For four interfaces, uncomment all four interfaces.
+# To enable Sriov ovs-hw-offload with bond/vf-lag, smart_nic should be enabled and bonding options uncommented
+# ComputeSriovInterface1 & ComputeSriovInterface2 form bond-pf0 and these interfaces should be from single nic
+# ComputeSriovInterface3 & ComputeSriovInterface4 form bond-pf1 and these interfaces should be from single nic
+# Ovs will not be offloaded if bonded interfaces are not from same nic.
 # Following lines should be commented out if sriov_enable is set to false
 #ComputeSriovInterface1=p1p1
-#ComputeSriovInterface2=p4p1
-#ComputeSriovInterface3=p1p2
+#ComputeSriovInterface2=p1p2
+#ComputeSriovInterface3=p4p1
 #ComputeSriovInterface4=p4p2
-
-# To enable SR-IOV with Hardware Offload enabled, two or four interfaces should be used.
-# For two interfaces, uncomment 'ControllerSriovInterface1' and 'ControllerSriovInterface2'.
-# For four interfaces, uncomment all four interfaces.
-# Following lines should be commented out if smart_nic is set to false
-#ControllerSriovInterface1=p1p1
-#ControllerSriovInterface2=p4p1
-#ControllerSriovInterface3=p1p2
-#ControllerSriovInterface4=p4p2
+#BondInterfaceSriovOptions=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
 # To enable SR-IOV and OVS-DPDK, four interfaces should be used.
 # Following lines should be uncommented if both sriov_enable and ovs-dpdk_enable are set to true.

--- a/src/deploy/osp_deployer/settings/sample_hci_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_hci_profile.ini
@@ -239,23 +239,19 @@ StorageBondInterfaceOptions=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 la
 #ComputeOvsDpdkInterface4=p3p2
 #BondInterfaceOvsOptions=bond_mode=balance-tcp lacp=active
 
-# To enable standalone SR-IOV, two or four interfaces should be used.
+# To enable standalone SR-IOV, two or four interfaces should be used without bonding options.
 # For two interfaces, uncomment 'ComputeSriovInterface1' and 'ComputeSriovInterface2'.
 # For four interfaces, uncomment all four interfaces.
+# To enable Sriov ovs-hw-offload with bond/vf-lag, smart_nic should be enabled and bonding options uncommented
+# ComputeSriovInterface1 & ComputeSriovInterface2 form bond-pf0 and these interfaces should be from single nic
+# ComputeSriovInterface3 & ComputeSriovInterface4 form bond-pf1 and these interfaces should be from single nic
+# Ovs will not be offloaded if bonded interfaces are not from same nic.
 # Following lines should be commented out if sriov_enable is set to false
 #ComputeSriovInterface1=p1p1
-#ComputeSriovInterface2=p4p1
-#ComputeSriovInterface3=p1p2
+#ComputeSriovInterface2=p1p2
+#ComputeSriovInterface3=p4p1
 #ComputeSriovInterface4=p4p2
-
-# To enable SR-IOV with Hardware Offload enabled, two or four interfaces should be used.
-# For two interfaces, uncomment 'ControllerSriovInterface1' and 'ControllerSriovInterface2'.
-# For four interfaces, uncomment all four interfaces.
-# Following lines should be commented out if smart_nic is set to false
-#ControllerSriovInterface1=p1p1
-#ControllerSriovInterface2=p4p1
-#ControllerSriovInterface3=p1p2
-#ControllerSriovInterface4=p4p2
+#BondInterfaceSriovOptions=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
 # To enable SR-IOV and OVS-DPDK, four interfaces should be used.
 # Following lines should be uncommented if both sriov_enable and ovs-dpdk_enable are set to true.

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -238,23 +238,19 @@ StorageBondInterfaceOptions=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 la
 #ComputeOvsDpdkInterface4=p3p2
 #BondInterfaceOvsOptions=bond_mode=balance-tcp lacp=active
 
-# To enable standalone SR-IOV, two or four interfaces should be used.
+# To enable standalone SR-IOV, two or four interfaces should be used without bonding options.
 # For two interfaces, uncomment 'ComputeSriovInterface1' and 'ComputeSriovInterface2'.
 # For four interfaces, uncomment all four interfaces.
+# To enable Sriov ovs-hw-offload with bond/vf-lag, smart_nic should be enabled and bonding options uncommented
+# ComputeSriovInterface1 & ComputeSriovInterface2 form bond-pf0 and these interfaces should be from single nic
+# ComputeSriovInterface3 & ComputeSriovInterface4 form bond-pf1 and these interfaces should be from single nic
+# Ovs will not be offloaded if bonded interfaces are not from same nic.
 # Following lines should be commented out if sriov_enable is set to false
 #ComputeSriovInterface1=p1p1
-#ComputeSriovInterface2=p4p1
-#ComputeSriovInterface3=p1p2
+#ComputeSriovInterface2=p1p2
+#ComputeSriovInterface3=p4p1
 #ComputeSriovInterface4=p4p2
-
-# To enable SR-IOV with Hardware Offload enabled, two or four interfaces should be used.
-# For two interfaces, uncomment 'ControllerSriovInterface1' and 'ControllerSriovInterface2'.
-# For four interfaces, uncomment all four interfaces.
-# Following lines should be commented out if smart_nic is set to false
-#ControllerSriovInterface1=p1p1
-#ControllerSriovInterface2=p4p1
-#ControllerSriovInterface3=p1p2
-#ControllerSriovInterface4=p4p2
+#BondInterfaceSriovOptions=mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
 # To enable SR-IOV and OVS-DPDK, four interfaces should be used.
 # Following lines should be uncommented if both sriov_enable and ovs-dpdk_enable are set to true.

--- a/src/pilot/dell_nfv.py
+++ b/src/pilot/dell_nfv.py
@@ -146,62 +146,6 @@ class ConfigOvercloud(object):
             kernel_args = ''
             if sriov or ovs_dpdk:
                 kernel_args = "iommu=pt intel_iommu=on"
-            if hw_offload:
-                vlan = str(vlan_range).split(':')
-                vlan_start = int(vlan[0])
-                vlan_end = int(vlan[1])
-                vlan_diff = vlan_end - vlan_start
-                if int(sriov_interfaces) == 2:
-                    vlan_a = (vlan_diff / 2) + vlan_start
-                    vlan_b = vlan_a + 1
-
-                    cmds.append(('sed -i "s|NeutronNetworkVLANRanges:.*' +
-                                 '|NeutronNetworkVLANRanges: ' +
-                                 'physint:' + str(vlan_start) +
-                                 ":" + str(vlan_a) +
-                                 ',physint1:' + str(vlan_b) +
-                                 ":" + str(vlan_end) +
-                                 ',physext' +
-                                 '|" ' +
-                                 file_path))
-                    cmds.append(('sed -i "s|NeutronBridgeMappings:.*' +
-                                 '|NeutronBridgeMappings: ' +
-                                 'physint:mlx_br1,' +
-                                 'physint1:mlx_br2,' +
-                                 'physext:br-ex' +
-                                 '|" ' +
-                                 file_path))
-
-                if int(sriov_interfaces) == 4:
-                    vlan_a = (vlan_diff / 4) + vlan_start
-                    vlan_b = vlan_a + 1
-                    vlan_c = (vlan_diff / 4) + vlan_b
-                    vlan_d = vlan_c + 1
-                    vlan_e = (vlan_diff / 4) + vlan_d
-                    vlan_f = vlan_e + 1
-
-                    cmds.append(('sed -i "s|NeutronNetworkVLANRanges:.*' +
-                                 '|NeutronNetworkVLANRanges: ' +
-                                 'physint:' + str(vlan_start) +
-                                 ":" + str(vlan_a) +
-                                 ',physint1:' + str(vlan_b) +
-                                 ":" + str(vlan_c) +
-                                 ',physint2:' + str(vlan_d) +
-                                 ":" + str(vlan_e) +
-                                 ',physint3:' + str(vlan_f) +
-                                 ":" + str(vlan_end) +
-                                 ',physext' +
-                                 '|" ' +
-                                 file_path))
-                    cmds.append(('sed -i "s|NeutronBridgeMappings:.*' +
-                                 '|NeutronBridgeMappings: ' +
-                                 'physint:mlx_br1,' +
-                                 'physint1:mlx_br2,' +
-                                 'physint2:mlx_br3,' +
-                                 'physint3:mlx_br4,' +
-                                 'physext:br-ex' +
-                                 '|" ' +
-                                 file_path))
 
             if enable_hugepage:
                 hpg_num = self.nfv_params.calculate_hugepage_count(

--- a/src/pilot/templates/nic-configs/sriov_6_port_offload/controller.yaml
+++ b/src/pilot/templates/nic-configs/sriov_6_port_offload/controller.yaml
@@ -55,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -105,43 +154,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  ControllerSriovInterface1:
-    default: p2p1
-    description: SRIOV bridge interface 1
-    type: string
-  ControllerSriovInterface2:
-    default: p2p2
-    description: SRIOV bridge interface 2
-    type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -160,9 +207,9 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-tenant
-                use_dhcp: false
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                    get_param: ProvisioningMtu
+                use_dhcp: false
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -192,7 +239,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -200,19 +247,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -221,7 +268,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -230,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -240,32 +287,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet
@@ -273,28 +320,6 @@ resources:
                   - ip_netmask: 0.0.0.0/0
                     next_hop:
                       get_param: ExternalInterfaceDefaultRoute
-              - type: ovs_bridge
-                name: mlx_br1
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ControllerSriovInterface1
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br2
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ControllerSriovInterface2
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/sriov_6_port_offload/dellcompute_sriov.yaml
+++ b/src/pilot/templates/nic-configs/sriov_6_port_offload/dellcompute_sriov.yaml
@@ -51,15 +51,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -95,44 +128,59 @@ parameters:
     type: string
   ComputeSriovInterface1:
     default: p2p1
-    description: SRIOV Interface 1 name
+    description: SRIOV bond-pf0 Interface 1 name
     type: string
   ComputeSriovInterface2:
     default: p3p1
-    description: SRIOV Interface 2 name
+    description: SRIOV bond-pf0 Interface 2 name
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  BondInterfaceSriovOptions:
+    default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
+    description: The bonding_options string for the bond interface.
+    type: string
+  NumSriovVfs: # Override this via parameter_defaults
+    default: 4
+    description: Number of SRIOV Virtual Functions.
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -145,10 +193,12 @@ resources:
           params:
             $network_config:
               network_config:
-              - type: ovs_bridge
-                name: br-tenant
+              - type: linux_bond
+                name: bond0
+                bonding_options:
+                  get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -166,96 +216,102 @@ resources:
                   next_hop:
                     get_param: ControlPlaneDefaultRoute
                 members:
+                - type: interface
+                  name:
+                    get_param: ComputeBond0Interface1
+                  mtu:
+                    get_param: DefaultBondMtu
+                  primary: true
+                - type: interface
+                  name:
+                    get_param: ComputeBond0Interface2
+                  mtu:
+                    get_param: DefaultBondMtu
+              - type: vlan
+                device: bond0
+                vlan_id:
+                  get_param: InternalApiNetworkVlanID
+                mtu:
+                  get_param: InternalApiMtu
+                addresses:
+                - ip_netmask:
+                    get_param: InternalApiIpSubnet
+              - type: vlan
+                device: bond0
+                vlan_id:
+                  get_param: TenantNetworkVlanID
+                mtu:
+                  get_param: TenantMtu
+                addresses:
+                - ip_netmask:
+                    get_param: TenantIpSubnet
+              # SRIOV Bridge (VF-LAG)
+              - type: ovs_bridge
+                name: br-tenant
+                use_dhcp: false
+                mtu:
+                  get_param: ProvisioningMtu
+                members:
                 - type: linux_bond
-                  name: bond0
+                  name: bond-pf0
                   bonding_options:
-                    get_param: ComputeBondInterfaceOptions
-                  mtu:
-                    get_param: DefaultBondMTU
+                    get_param: BondInterfaceSriovOptions
                   members:
-                  - type: interface
+                  - type: sriov_pf
                     name:
-                      get_param: ComputeBond0Interface1
+                      get_param: ComputeSriovInterface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
+                    numvfs:
+                      get_param: NumSriovVfs
                     primary: true
-                  - type: interface
+                    promisc: true
+                    use_dhcp: false
+                    defroute: false
+                    link_mode: switchdev
+                  - type: sriov_pf
                     name:
-                      get_param: ComputeBond0Interface2
+                      get_param: ComputeSriovInterface2
                     mtu:
-                      get_param: DefaultBondMTU
-                - type: vlan
-                  device: bond0
-                  vlan_id:
-                    get_param: TenantNetworkVlanID
-                  mtu:
-                    get_param: TenantNetworkMTU
-                  addresses:
-                  - ip_netmask:
-                      get_param: TenantIpSubnet
-                - type: vlan
-                  device: bond0
-                  vlan_id:
-                    get_param: InternalApiNetworkVlanID
-                  mtu:
-                    get_param: InternalApiMTU
-                  addresses:
-                  - ip_netmask:
-                      get_param: InternalApiIpSubnet
+                      get_param: DefaultBondMtu
+                    numvfs:
+                      get_param: NumSriovVfs
+                    promisc: true
+                    use_dhcp: false
+                    defroute: false
+                    link_mode: switchdev
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
-              - type: ovs_bridge
-                name: mlx_br1
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ComputeSriovInterface1
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br2
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ComputeSriovInterface2
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/sriov_6_port_offload/nic_environment.yaml
+++ b/src/pilot/templates/nic-configs/sriov_6_port_offload/nic_environment.yaml
@@ -57,9 +57,6 @@ parameter_defaults:
   # SRIOV bonds
   ComputeSriovInterface1: p1p1
   ComputeSriovInterface2: p4p1
+  # The bonding mode to use for SRIOV VF-LAG
+  BondInterfaceSriovOptions: 802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
-  # CHANGEME: Change the interface names in the following lines for the
-  # controller nodes interfaces and include in the bridges
-  # for DHCP server communication
-  ControllerSriovInterface1: p1p2
-  ControllerSriovInterface2: p4p2

--- a/src/pilot/templates/nic-configs/sriov_6_port_offload/storage.yaml
+++ b/src/pilot/templates/nic-configs/sriov_6_port_offload/storage.yaml
@@ -55,15 +55,40 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -97,34 +122,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -139,11 +171,11 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-bond0
-                mtu:
-                  get_param: ProvisioningNetworkMTU
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
+                mtu:
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -161,7 +193,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -169,51 +201,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/sriov_7_port_offload/controller.yaml
+++ b/src/pilot/templates/nic-configs/sriov_7_port_offload/controller.yaml
@@ -55,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -109,43 +158,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  ControllerSriovInterface1:
-    default: p2p1
-    description: SRIOV bridge interface 1
-    type: string
-  ControllerSriovInterface2:
-    default: p2p2
-    description: SRIOV bridge interface 2
-    type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
@@ -167,7 +214,7 @@ resources:
                   get_param: ControllerProvisioningInterface
                 use_dhcp: false
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -196,12 +243,12 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -209,19 +256,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -230,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -239,7 +286,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -249,32 +296,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet
@@ -282,28 +329,6 @@ resources:
                   - ip_netmask: 0.0.0.0/0
                     next_hop:
                       get_param: ExternalInterfaceDefaultRoute
-              - type: ovs_bridge
-                name: mlx_br1
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ControllerSriovInterface1
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br2
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ControllerSriovInterface2
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/sriov_7_port_offload/dellcompute_sriov.yaml
+++ b/src/pilot/templates/nic-configs/sriov_7_port_offload/dellcompute_sriov.yaml
@@ -1,7 +1,6 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for compute nodes. comment14_0: ' The values of the following parameters are overridden by the
-  entries in' comment15_0: ' network-environment.yaml'
+  Bond and VLAN configuration for compute nodes.
 parameters:
   ControlPlaneIp:
     default: ''
@@ -51,15 +50,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -82,7 +114,7 @@ parameters:
     description: Bond 0 interface 1 name
     type: string
   ComputeBond0Interface2:
-    default: p3p1
+    default: p1p1
     description: Bond 0 interface 2 name
     type: string
   ComputeBond1Interface1:
@@ -90,7 +122,7 @@ parameters:
     description: Bond 1 interface 1 name
     type: string
   ComputeBond1Interface2:
-    default: p3p2
+    default: p1p2
     description: Bond 1 interface 2 name
     type: string
   ComputeBondInterfaceOptions:
@@ -99,44 +131,59 @@ parameters:
     type: string
   ComputeSriovInterface1:
     default: p2p1
-    description: SRIOV Interface 1 name
+    description: SRIOV bond-pf0 Interface 1 name
     type: string
   ComputeSriovInterface2:
     default: p3p1
-    description: SRIOV Interface 2 name
+    description: SRIOV bond-pf0 Interface 2 name
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  BondInterfaceSriovOptions:
+    default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
+    description: The bonding_options string for the bond interface.
+    type: string
+  NumSriovVfs: # Override this via parameter_defaults
+    default: 4
+    description: Number of SRIOV Virtual Functions.
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -153,7 +200,7 @@ resources:
                 name:
                   get_param: ComputeProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -170,101 +217,104 @@ resources:
                 - default: true
                   next_hop:
                     get_param: ControlPlaneDefaultRoute
+              - type: linux_bond
+                name: bond0
+                bonding_options:
+                  get_param: ComputeBondInterfaceOptions
+                mtu:
+                  get_param: DefaultBondMtu
+                members:
+                - type: interface
+                  name:
+                    get_param: ComputeBond0Interface1
+                  mtu:
+                    get_param: DefaultBondMtu
+                  primary: true
+                - type: interface
+                  name:
+                    get_param: ComputeBond0Interface2
+                  mtu:
+                    get_param: DefaultBondMtu
+              - type: vlan
+                device: bond0
+                vlan_id:
+                  get_param: TenantNetworkVlanID
+                mtu:
+                  get_param: TenantMtu
+                addresses:
+                - ip_netmask:
+                    get_param: TenantIpSubnet
+              - type: vlan
+                device: bond0
+                vlan_id:
+                  get_param: InternalApiNetworkVlanID
+                mtu:
+                  get_param: InternalApiMtu
+                addresses:
+                - ip_netmask:
+                    get_param: InternalApiIpSubnet
+              # SRIOV Bridge (VF-LAG)
               - type: ovs_bridge
                 name: br-tenant
+                use_dhcp: false
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: ProvisioningMtu
                 members:
                 - type: linux_bond
-                  name: bond0
+                  name: bond-pf0
                   bonding_options:
-                    get_param: ComputeBondInterfaceOptions
-                  mtu:
-                    get_param: DefaultBondMTU
+                    get_param: BondInterfaceSriovOptions
                   members:
-                  - type: interface
+                  - type: sriov_pf
                     name:
-                      get_param: ComputeBond0Interface1
+                      get_param: ComputeSriovInterface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
+                    numvfs:
+                      get_param: NumSriovVfs
                     primary: true
-                  - type: interface
+                    promisc: true
+                    use_dhcp: false
+                    defroute: false
+                    link_mode: switchdev
+                  - type: sriov_pf
                     name:
-                      get_param: ComputeBond0Interface2
+                      get_param: ComputeSriovInterface2
                     mtu:
-                      get_param: DefaultBondMTU
-                - type: vlan
-                  device: bond0
-                  vlan_id:
-                    get_param: TenantNetworkVlanID
-                  mtu:
-                    get_param: TenantNetworkMTU
-                  addresses:
-                  - ip_netmask:
-                      get_param: TenantIpSubnet
-                - type: vlan
-                  device: bond0
-                  vlan_id:
-                    get_param: InternalApiNetworkVlanID
-                  mtu:
-                    get_param: InternalApiMTU
-                  addresses:
-                  - ip_netmask:
-                      get_param: InternalApiIpSubnet
-              - type: ovs_bridge
-                name: br-bond1
+                      get_param: DefaultBondMtu
+                    numvfs:
+                      get_param: NumSriovVfs
+                    promisc: true
+                    use_dhcp: false
+                    defroute: false
+                    link_mode: switchdev
+              - type: linux_bond
+                name: bond1
+                bonding_options:
+                  get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: linux_bond
-                  name: bond1
-                  bonding_options:
-                    get_param: ComputeBondInterfaceOptions
-                  mtu:
-                    get_param: DefaultBondMTU
-                  members:
-                  - type: interface
-                    name:
-                      get_param: ComputeBond1Interface1
-                    mtu:
-                      get_param: DefaultBondMTU
-                    primary: true
-                  - type: interface
-                    name:
-                      get_param: ComputeBond1Interface2
-                    mtu:
-                      get_param: DefaultBondMTU
-                - type: vlan
-                  device: bond1
-                  vlan_id:
-                    get_param: StorageNetworkVlanID
-                  mtu:
-                    get_param: StorageNetworkMTU
-                  addresses:
-                  - ip_netmask:
-                      get_param: StorageIpSubnet
-              - type: ovs_bridge
-                name: mlx_br1
-                mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
-                    get_param: ComputeSriovInterface1
+                    get_param: ComputeBond1Interface1
                   mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br2
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
+                    get_param: DefaultBondMtu
+                  primary: true
                 - type: interface
                   name:
-                    get_param: ComputeSriovInterface2
+                    get_param: ComputeBond1Interface2
                   mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
+                    get_param: DefaultBondMtu
+              - type: vlan
+                device: bond1
+                vlan_id:
+                  get_param: StorageNetworkVlanID
+                mtu:
+                  get_param: StorageMtu
+                addresses:
+                - ip_netmask:
+                    get_param: StorageIpSubnet
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/sriov_7_port_offload/nic_environment.yaml
+++ b/src/pilot/templates/nic-configs/sriov_7_port_offload/nic_environment.yaml
@@ -57,9 +57,6 @@ parameter_defaults:
   # SRIOV bonds
   ComputeSriovInterface1: p1p1
   ComputeSriovInterface2: p4p1
+  # The bonding mode to use for SRIOV VF-LAG
+  BondInterfaceSriovOptions: 802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
-  # CHANGEME: Change the interface names in the following lines for the
-  # controller nodes interfaces and include in the bridges
-  # for DHCP server communication
-  ControllerSriovInterface1: p1p2
-  ControllerSriovInterface2: p4p2

--- a/src/pilot/templates/nic-configs/sriov_7_port_offload/storage.yaml
+++ b/src/pilot/templates/nic-configs/sriov_7_port_offload/storage.yaml
@@ -55,15 +55,45 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneNetCidr:
+    description: Control plane/provisioning network and mask
+    type: string
+    default: ''
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
+    default: ''
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -101,34 +131,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -145,7 +182,7 @@ resources:
                 name:
                   get_param: StorageProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -165,12 +202,12 @@ resources:
               - type: ovs_bridge
                 name: br-bond0
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -178,51 +215,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/sriov_8_port_offload/controller.yaml
+++ b/src/pilot/templates/nic-configs/sriov_8_port_offload/controller.yaml
@@ -55,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -105,54 +154,45 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  ControllerSriovInterface1:
-    default: p2p1
-    description: SRIOV bridge interface 1
-    type: string
-  ControllerSriovInterface2:
-    default: p2p2
-    description: SRIOV bridge interface 2
-    type: string
-  ControllerSriovInterface3:
-    default: p2p3
-    description: SRIOV bridge interface 3
-    type: string
-  ControllerSriovInterface4:
-    default: p2p4
-    description: SRIOV bridge interface 4
-    type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -167,9 +207,9 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-tenant
-                use_dhcp: false
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                    get_param: ProvisioningMtu
+                use_dhcp: false
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -199,7 +239,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -207,19 +247,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -228,7 +268,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -237,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -247,32 +287,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet
@@ -280,50 +320,6 @@ resources:
                   - ip_netmask: 0.0.0.0/0
                     next_hop:
                       get_param: ExternalInterfaceDefaultRoute
-              - type: ovs_bridge
-                name: mlx_br1
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ControllerSriovInterface1
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br2
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ControllerSriovInterface2
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br3
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ControllerSriovInterface3
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br4
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ControllerSriovInterface4
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/sriov_8_port_offload/dellcompute_sriov.yaml
+++ b/src/pilot/templates/nic-configs/sriov_8_port_offload/dellcompute_sriov.yaml
@@ -51,15 +51,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -95,52 +128,67 @@ parameters:
     type: string
   ComputeSriovInterface1:
     default: p2p1
-    description: SRIOV Interface 1 name
+    description: SRIOV bond-pf0 Interface 1 name
     type: string
   ComputeSriovInterface2:
     default: p3p1
-    description: SRIOV Interface 2 name
+    description: SRIOV bond-pf0 Interface 2 name
     type: string
   ComputeSriovInterface3:
-    default: p2p2
-    description: SRIOV Interface 3 name
+    default: p2p1
+    description: SRIOV bond-pf1 Interface 1 name
     type: string
   ComputeSriovInterface4:
-    default: p3p2
-    description: SRIOV Interface 4 name
+    default: p3p1
+    description: SRIOV bond-pf1 Interface 2 name
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  BondInterfaceSriovOptions:
+    default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
+    description: The bonding_options string for the bond interface.
+    type: string
+  NumSriovVfs: # Override this via parameter_defaults
+    default: 4
+    description: Number of SRIOV Virtual Functions.
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -153,10 +201,12 @@ resources:
           params:
             $network_config:
               network_config:
-              - type: ovs_bridge
-                name: br-tenant
+              - type: linux_bond
+                name: bond0
+                bonding_options:
+                  get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -174,118 +224,130 @@ resources:
                   next_hop:
                     get_param: ControlPlaneDefaultRoute
                 members:
+                - type: interface
+                  name:
+                    get_param: ComputeBond0Interface1
+                  mtu:
+                    get_param: DefaultBondMtu
+                  primary: true
+                - type: interface
+                  name:
+                    get_param: ComputeBond0Interface2
+                  mtu:
+                    get_param: DefaultBondMtu
+              - type: vlan
+                device: bond0
+                vlan_id:
+                  get_param: InternalApiNetworkVlanID
+                mtu:
+                  get_param: InternalApiMtu
+                addresses:
+                - ip_netmask:
+                    get_param: InternalApiIpSubnet
+              - type: vlan
+                device: bond0
+                vlan_id:
+                  get_param: TenantNetworkVlanID
+                mtu:
+                  get_param: TenantMtu
+                addresses:
+                - ip_netmask:
+                    get_param: TenantIpSubnet
+              # SRIOV Bridge (VF-LAG)
+              - type: ovs_bridge
+                name: br-tenant
+                use_dhcp: false
+                mtu:
+                  get_param: ProvisioningMtu
+                members:
                 - type: linux_bond
-                  name: bond0
+                  name: bond-pf0
                   bonding_options:
-                    get_param: ComputeBondInterfaceOptions
-                  mtu:
-                    get_param: DefaultBondMTU
+                    get_param: BondInterfaceSriovOptions
                   members:
-                  - type: interface
+                  - type: sriov_pf
                     name:
-                      get_param: ComputeBond0Interface1
+                      get_param: ComputeSriovInterface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
+                    numvfs:
+                      get_param: NumSriovVfs
                     primary: true
-                  - type: interface
+                    promisc: true
+                    use_dhcp: false
+                    defroute: false
+                    link_mode: switchdev
+                  - type: sriov_pf
                     name:
-                      get_param: ComputeBond0Interface2
+                      get_param: ComputeSriovInterface2
                     mtu:
-                      get_param: DefaultBondMTU
-                - type: vlan
-                  device: bond0
-                  vlan_id:
-                    get_param: TenantNetworkVlanID
-                  mtu:
-                    get_param: TenantNetworkMTU
-                  addresses:
-                  - ip_netmask:
-                      get_param: TenantIpSubnet
-                - type: vlan
-                  device: bond0
-                  vlan_id:
-                    get_param: InternalApiNetworkVlanID
-                  mtu:
-                    get_param: InternalApiMTU
-                  addresses:
-                  - ip_netmask:
-                      get_param: InternalApiIpSubnet
+                      get_param: DefaultBondMtu
+                    numvfs:
+                      get_param: NumSriovVfs
+                    promisc: true
+                    use_dhcp: false
+                    defroute: false
+                    link_mode: switchdev
+                - type: linux_bond
+                  name: bond-pf1
+                  bonding_options:
+                    get_param: BondInterfaceSriovOptions
+                  members:
+                  - type: sriov_pf
+                    name:
+                      get_param: ComputeSriovInterface3
+                    mtu:
+                      get_param: DefaultBondMtu
+                    numvfs:
+                      get_param: NumSriovVfs
+                    primary: true
+                    promisc: true
+                    use_dhcp: false
+                    defroute: false
+                    link_mode: switchdev
+                  - type: sriov_pf
+                    name:
+                      get_param: ComputeSriovInterface4
+                    mtu:
+                      get_param: DefaultBondMtu
+                    numvfs:
+                      get_param: NumSriovVfs
+                    promisc: true
+                    use_dhcp: false
+                    defroute: false
+                    link_mode: switchdev
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ComputeBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ComputeBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
-              - type: ovs_bridge
-                name: mlx_br1
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ComputeSriovInterface1
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br2
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ComputeSriovInterface2
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br3
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ComputeSriovInterface3
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br4
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ComputeSriovInterface4
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/sriov_8_port_offload/nic_environment.yaml
+++ b/src/pilot/templates/nic-configs/sriov_8_port_offload/nic_environment.yaml
@@ -55,15 +55,12 @@ parameter_defaults:
   # CHANGEME: Change the interface names in the following lines for the
   # compute nodes provisioning interface and to include in the compute
   # SRIOV bonds
-  ComputeSriovInterface1: p1p1
-  ComputeSriovInterface2: p4p1
-  ComputeSriovInterface3: p1p2
-  ComputeSriovInterface4: p4p2
+  # bond-pf0 interfaces
+  ComputeSriovInterface1: ens1f0
+  ComputeSriovInterface2: ens1f1
+  # bond-pf1 interfaces
+  ComputeSriovInterface3: ens2f0
+  ComputeSriovInterface4: ens2f1
+  # The bonding mode to use for SRIOV VF-LAG
+  BondInterfaceSriovOptions: 802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
-  # CHANGEME: Change the interface names in the following lines for the
-  # controller nodes interfaces and include in the bridges
-  # for DHCP server communication
-  ControllerSriovInterface1: p1p2
-  ControllerSriovInterface2: p4p2
-  ControllerSriovInterface3: p3p2
-  ControllerSriovInterface4: p5p2

--- a/src/pilot/templates/nic-configs/sriov_8_port_offload/storage.yaml
+++ b/src/pilot/templates/nic-configs/sriov_8_port_offload/storage.yaml
@@ -55,15 +55,40 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -97,34 +122,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -139,11 +171,11 @@ resources:
               network_config:
               - type: ovs_bridge
                 name: br-bond0
-                mtu:
-                  get_param: ProvisioningNetworkMTU
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
+                mtu:
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -161,7 +193,7 @@ resources:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -169,51 +201,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet

--- a/src/pilot/templates/nic-configs/sriov_9_port_offload/controller.yaml
+++ b/src/pilot/templates/nic-configs/sriov_9_port_offload/controller.yaml
@@ -55,20 +55,69 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
+    type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  ExternalInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the external network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute:
-    default: 10.0.0.1
     description: default route for the external network
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
     default: unset
     description: The default route of the management network.
-    type: string
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
     type: string
   DnsServers: # Override this via parameter_defaults
     default: []
@@ -109,54 +158,45 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  ControllerSriovInterface1:
-    default: p2p1
-    description: SRIOV bridge interface 1
-    type: string
-  ControllerSriovInterface2:
-    default: p2p2
-    description: SRIOV bridge interface 2
-    type: string
-  ControllerSriovInterface3:
-    default: p2p3
-    description: SRIOV bridge interface 3
-    type: string
-  ControllerSriovInterface4:
-    default: p2p4
-    description: SRIOV bridge interface 4
-    type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
-  ExternalNetworkMTU:
+  ExternalMtu:
     default: 1500
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -174,7 +214,7 @@ resources:
                   get_param: ControllerProvisioningInterface
                 use_dhcp: false
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 addresses:
                 - ip_netmask:
                     list_join:
@@ -203,12 +243,12 @@ resources:
               - type: ovs_bridge
                 name: br-tenant
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   members:
@@ -216,19 +256,19 @@ resources:
                     name:
                       get_param: ControllerBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: TenantNetworkVlanID
                   mtu:
-                    get_param: TenantNetworkMTU
+                    get_param: TenantMtu
                   addresses:
                   - ip_netmask:
                       get_param: TenantIpSubnet
@@ -237,7 +277,7 @@ resources:
                   vlan_id:
                     get_param: InternalApiNetworkVlanID
                   mtu:
-                    get_param: InternalApiMTU
+                    get_param: InternalApiMtu
                   addresses:
                   - ip_netmask:
                       get_param: InternalApiIpSubnet
@@ -246,7 +286,7 @@ resources:
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
@@ -256,32 +296,32 @@ resources:
                 dns_servers:
                   get_param: DnsServers
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: ControllerBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: ControllerBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: ExternalNetworkVlanID
                   mtu:
-                    get_param: ExternalNetworkMTU
+                    get_param: ExternalMtu
                   addresses:
                   - ip_netmask:
                       get_param: ExternalIpSubnet
@@ -289,50 +329,6 @@ resources:
                   - ip_netmask: 0.0.0.0/0
                     next_hop:
                       get_param: ExternalInterfaceDefaultRoute
-              - type: ovs_bridge
-                name: mlx_br1
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ControllerSriovInterface1
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br2
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ControllerSriovInterface2
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br3
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ControllerSriovInterface3
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br4
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ControllerSriovInterface4
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/sriov_9_port_offload/dellcompute_sriov.yaml
+++ b/src/pilot/templates/nic-configs/sriov_9_port_offload/dellcompute_sriov.yaml
@@ -1,7 +1,6 @@
 heat_template_version: rocky
 description: >
-  Bond and VLAN configuration for compute nodes. comment14_0: ' The values of the following parameters are overridden by the
-  entries in' comment15_0: ' network-environment.yaml'
+  Bond and VLAN configuration for compute nodes.
 parameters:
   ControlPlaneIp:
     default: ''
@@ -51,15 +50,48 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  InternalApiInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the internal_api network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  TenantInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the tenant network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -82,7 +114,7 @@ parameters:
     description: Bond 0 interface 1 name
     type: string
   ComputeBond0Interface2:
-    default: p3p1
+    default: p1p1
     description: Bond 0 interface 2 name
     type: string
   ComputeBond1Interface1:
@@ -90,7 +122,7 @@ parameters:
     description: Bond 1 interface 1 name
     type: string
   ComputeBond1Interface2:
-    default: p3p2
+    default: p1p2
     description: Bond 1 interface 2 name
     type: string
   ComputeBondInterfaceOptions:
@@ -99,52 +131,67 @@ parameters:
     type: string
   ComputeSriovInterface1:
     default: p2p1
-    description: SRIOV Interface 1 name
+    description: SRIOV bond-pf0 Interface 1 name
     type: string
   ComputeSriovInterface2:
     default: p3p1
-    description: SRIOV Interface 2 name
+    description: SRIOV bond-pf0 Interface 2 name
     type: string
   ComputeSriovInterface3:
-    default: p2p2
-    description: SRIOV Interface 3 name
+    default: p2p1
+    description: SRIOV bond-pf1 Interface 1 name
     type: string
   ComputeSriovInterface4:
-    default: p3p2
-    description: SRIOV Interface 4 name
+    default: p3p1
+    description: SRIOV bond-pf1 Interface 2 name
     type: string
-  ExternalNetworkMTU: # Override this via parameter_defaults
+  BondInterfaceSriovOptions:
+    default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
+    description: The bonding_options string for the bond interface.
+    type: string
+  NumSriovVfs: # Override this via parameter_defaults
+    default: 4
+    description: Number of SRIOV Virtual Functions.
+    type: number
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  ExternalMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  InternalApiMTU: # Override this via parameter_defaults
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -161,7 +208,7 @@ resources:
                 name:
                   get_param: ComputeProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -178,123 +225,132 @@ resources:
                 - default: true
                   next_hop:
                     get_param: ControlPlaneDefaultRoute
+              - type: linux_bond
+                name: bond0
+                bonding_options:
+                  get_param: ComputeBondInterfaceOptions
+                mtu:
+                  get_param: DefaultBondMtu
+                members:
+                - type: interface
+                  name:
+                    get_param: ComputeBond0Interface1
+                  mtu:
+                    get_param: DefaultBondMtu
+                  primary: true
+                - type: interface
+                  name:
+                    get_param: ComputeBond0Interface2
+                  mtu:
+                    get_param: DefaultBondMtu
+              - type: vlan
+                device: bond0
+                vlan_id:
+                  get_param: TenantNetworkVlanID
+                mtu:
+                  get_param: TenantMtu
+                addresses:
+                - ip_netmask:
+                    get_param: TenantIpSubnet
+              - type: vlan
+                device: bond0
+                vlan_id:
+                  get_param: InternalApiNetworkVlanID
+                mtu:
+                  get_param: InternalApiMtu
+                addresses:
+                - ip_netmask:
+                    get_param: InternalApiIpSubnet
+              # SRIOV Bridge (VF-LAG)
               - type: ovs_bridge
                 name: br-tenant
+                use_dhcp: false
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: ProvisioningMtu
                 members:
                 - type: linux_bond
-                  name: bond0
+                  name: bond-pf0
                   bonding_options:
-                    get_param: ComputeBondInterfaceOptions
-                  mtu:
-                    get_param: DefaultBondMTU
+                    get_param: BondInterfaceSriovOptions
                   members:
-                  - type: interface
+                  - type: sriov_pf
                     name:
-                      get_param: ComputeBond0Interface1
+                      get_param: ComputeSriovInterface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
+                    numvfs:
+                      get_param: NumSriovVfs
                     primary: true
-                  - type: interface
+                    promisc: true
+                    use_dhcp: false
+                    defroute: false
+                    link_mode: switchdev
+                  - type: sriov_pf
                     name:
-                      get_param: ComputeBond0Interface2
+                      get_param: ComputeSriovInterface2
                     mtu:
-                      get_param: DefaultBondMTU
-                - type: vlan
-                  device: bond0
-                  vlan_id:
-                    get_param: TenantNetworkVlanID
-                  mtu:
-                    get_param: TenantNetworkMTU
-                  addresses:
-                  - ip_netmask:
-                      get_param: TenantIpSubnet
-                - type: vlan
-                  device: bond0
-                  vlan_id:
-                    get_param: InternalApiNetworkVlanID
-                  mtu:
-                    get_param: InternalApiMTU
-                  addresses:
-                  - ip_netmask:
-                      get_param: InternalApiIpSubnet
-              - type: ovs_bridge
-                name: br-bond1
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
+                      get_param: DefaultBondMtu
+                    numvfs:
+                      get_param: NumSriovVfs
+                    promisc: true
+                    use_dhcp: false
+                    defroute: false
+                    link_mode: switchdev
                 - type: linux_bond
-                  name: bond1
+                  name: bond-pf1
                   bonding_options:
-                    get_param: ComputeBondInterfaceOptions
-                  mtu:
-                    get_param: DefaultBondMTU
+                    get_param: BondInterfaceSriovOptions
                   members:
-                  - type: interface
+                  - type: sriov_pf
                     name:
-                      get_param: ComputeBond1Interface1
+                      get_param: ComputeSriovInterface3
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
+                    numvfs:
+                      get_param: NumSriovVfs
                     primary: true
-                  - type: interface
+                    promisc: true
+                    use_dhcp: false
+                    defroute: false
+                    link_mode: switchdev
+                  - type: sriov_pf
                     name:
-                      get_param: ComputeBond1Interface2
+                      get_param: ComputeSriovInterface4
                     mtu:
-                      get_param: DefaultBondMTU
-                - type: vlan
-                  device: bond1
-                  vlan_id:
-                    get_param: StorageNetworkVlanID
-                  mtu:
-                    get_param: StorageNetworkMTU
-                  addresses:
-                  - ip_netmask:
-                      get_param: StorageIpSubnet
-              - type: ovs_bridge
-                name: mlx_br1
+                      get_param: DefaultBondMtu
+                    numvfs:
+                      get_param: NumSriovVfs
+                    promisc: true
+                    use_dhcp: false
+                    defroute: false
+                    link_mode: switchdev
+              - type: linux_bond
+                name: bond1
+                bonding_options:
+                  get_param: ComputeBondInterfaceOptions
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: interface
                   name:
-                    get_param: ComputeSriovInterface1
+                    get_param: ComputeBond1Interface1
                   mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br2
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
+                    get_param: DefaultBondMtu
+                  primary: true
                 - type: interface
                   name:
-                    get_param: ComputeSriovInterface2
+                    get_param: ComputeBond1Interface2
                   mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br3
+                    get_param: DefaultBondMtu
+              - type: vlan
+                device: bond1
+                vlan_id:
+                  get_param: StorageNetworkVlanID
                 mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ComputeSriovInterface3
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
-              - type: ovs_bridge
-                name: mlx_br4
-                mtu:
-                  get_param: DefaultBondMTU
-                members:
-                - type: interface
-                  name:
-                    get_param: ComputeSriovInterface4
-                  mtu:
-                    get_param: DefaultBondMTU
-                  use_dhcp: false
+                  get_param: StorageMtu
+                addresses:
+                - ip_netmask:
+                    get_param: StorageIpSubnet
 outputs:
   OS::stack_id:
     description: The OsNetConfigImpl resource.

--- a/src/pilot/templates/nic-configs/sriov_9_port_offload/nic_environment.yaml
+++ b/src/pilot/templates/nic-configs/sriov_9_port_offload/nic_environment.yaml
@@ -55,15 +55,13 @@ parameter_defaults:
   # CHANGEME: Change the interface names in the following lines for the
   # compute nodes provisioning interface and to include in the compute
   # SRIOV bonds
-  ComputeSriovInterface1: p1p1
-  ComputeSriovInterface2: p4p1
-  ComputeSriovInterface3: p1p2
-  ComputeSriovInterface4: p4p2
+  # bond-pf0 interfaces
+  ComputeSriovInterface1: ens1f0
+  ComputeSriovInterface2: ens1f1
+  # bond-pf1 interfaces
+  ComputeSriovInterface3: ens2f0
+  ComputeSriovInterface4: ens2f1
+  # The bonding mode to use for SRIOV VF-LAG
+  BondInterfaceSriovOptions: 802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
 
-  # CHANGEME: Change the interface names in the following lines for the
-  # controller nodes interfaces and include in the bridges
-  # for DHCP server communication
-  ControllerSriovInterface1: p1p2
-  ControllerSriovInterface2: p4p2
-  ControllerSriovInterface3: p3p2
-  ControllerSriovInterface4: p5p2
+

--- a/src/pilot/templates/nic-configs/sriov_9_port_offload/storage.yaml
+++ b/src/pilot/templates/nic-configs/sriov_9_port_offload/storage.yaml
@@ -55,15 +55,45 @@ parameters:
     default: 60
     description: Vlan ID for the management network traffic.
     type: number
-  ControlPlaneSubnetCidr: # Override this via parameter_defaults
-    default: '24'
-    description: The subnet CIDR of the control plane network.
+  ControlPlaneSubnetCidr:
+    default: ''
+    description: >
+      The subnet CIDR of the control plane network. (The parameter is
+      automatically resolved from the ctlplane subnet's cidr attribute.)
     type: string
+  ControlPlaneNetCidr:
+    description: Control plane/provisioning network and mask
+    type: string
+    default: ''
+  ControlPlaneStaticRoutes:
+    default: []
+    description: >
+      Routes for the ctlplane network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
+  StorageMgmtInterfaceRoutes:
+    default: []
+    description: >
+      Routes for the storage_mgmt network traffic.
+      JSON route e.g. [{'destination':'10.0.0.0/16', 'nexthop':'10.0.0.1'}]
+      Unless the default is changed, the parameter is automatically resolved
+      from the subnet host_routes attribute.
+    type: json
   ControlPlaneDefaultRoute: # Override this via parameter_defaults
     description: The default route of the control plane network.
     type: string
   ExternalInterfaceDefaultRoute: # Not used by default in this template
-    default: 10.0.0.1
+    default: ''
     description: The default route of the external network.
     type: string
   ManagementInterfaceDefaultRoute: # Commented out by default in this template
@@ -101,34 +131,41 @@ parameters:
     default: mode=802.3ad miimon=100 xmit_hash_policy=layer3+4 lacp_rate=1
     description: The bonding_options string for the bond interface.
     type: string
-  InternalApiMTU: # Override this via parameter_defaults
+  ControlPlaneMtu:
+    default: 1500
+    description: The maximum transmission unit (MTU) size(in bytes) that is
+      guaranteed to pass through the data path of the segments in the network.
+      (The parameter is automatically resolved from the ctlplane network's mtu attribute.)
+    type: number
+  InternalApiMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageNetworkMTU: # Override this via parameter_defaults
+  StorageMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  StorageMgmtNetworkMTU: # Override this via parameter_defaults
+  StorageMgmtMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  TenantNetworkMTU: # Override this via parameter_defaults
+  TenantMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ProvisioningNetworkMTU: # Override this via parameter_defaults
+  ProvisioningMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  ManagementNetworkMTU: # Override this via parameter_defaults
+  ManagementMtu: # Override this via parameter_defaults
     default: 1500
     description: MTU value for this network.
     type: number
-  DefaultBondMTU: # Override this via parameter_defaults
+  DefaultBondMtu: # Override this via parameter_defaults
     default: 9000
     description: MTU value for this network.
     type: number
+
 resources:
   OsNetConfigImpl:
     type: OS::Heat::SoftwareConfig
@@ -145,7 +182,7 @@ resources:
                 name:
                   get_param: StorageProvisioningInterface
                 mtu:
-                  get_param: ProvisioningNetworkMTU
+                  get_param: ProvisioningMtu
                 use_dhcp: false
                 dns_servers:
                   get_param: DnsServers
@@ -165,12 +202,12 @@ resources:
               - type: ovs_bridge
                 name: br-bond0
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond0
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   members:
@@ -178,51 +215,51 @@ resources:
                     name:
                       get_param: StorageBond0Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond0Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond0
                   vlan_id:
                     get_param: StorageNetworkVlanID
                   mtu:
-                    get_param: StorageNetworkMTU
+                    get_param: StorageMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageIpSubnet
               - type: ovs_bridge
                 name: br-bond1
                 mtu:
-                  get_param: DefaultBondMTU
+                  get_param: DefaultBondMtu
                 members:
                 - type: linux_bond
                   name: bond1
                   bonding_options:
                     get_param: StorageBondInterfaceOptions
                   mtu:
-                    get_param: DefaultBondMTU
+                    get_param: DefaultBondMtu
                   members:
                   - type: interface
                     name:
                       get_param: StorageBond1Interface1
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                     primary: true
                   - type: interface
                     name:
                       get_param: StorageBond1Interface2
                     mtu:
-                      get_param: DefaultBondMTU
+                      get_param: DefaultBondMtu
                 - type: vlan
                   device: bond1
                   vlan_id:
                     get_param: StorageMgmtNetworkVlanID
                   mtu:
-                    get_param: StorageMgmtNetworkMTU
+                    get_param: StorageMgmtMtu
                   addresses:
                   - ip_netmask:
                       get_param: StorageMgmtIpSubnet


### PR DESCRIPTION
- Support for sriov ovs-hw-offload in JS16.1
- Removes the additional dedicated NICs from Controller nodes for offload
- VF-LAG (SRIOV bonding) is implemented on compute nodes
- Has been tested for 6 port and 8 port deployments