### PR TITLE
fixing timezone on overcloud nodes

### DIFF
--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -1820,7 +1820,10 @@ class Director(InfraHost):
                                     " --ntp " + \
                                     self.settings.sah_node.provisioning_ip + \
                                     " --mtu " + \
-                                    self.settings.default_bond_mtu
+                                    self.settings.default_bond_mtu + \
+                                    " --timezone " + \
+                                    self.settings.time_zone
+
 
         if self.settings.hpg_enable is True:
             cmd += " --enable_hugepages "

--- a/src/pilot/dell_nfv.py
+++ b/src/pilot/dell_nfv.py
@@ -86,9 +86,11 @@ class ConfigOvercloud(object):
             swift_storage_flavor,
             block_storage_flavor,
             vlan_range,
+            time_zone,
             dell_compute_count=0,
             dell_computehci_count=0,
             dell_powerflex_count=0):
+
         try:
             logger.info("Editing dell environment file")
             file_path = home_dir + '/pilot/templates/dell-environment.yaml'
@@ -226,6 +228,13 @@ class ConfigOvercloud(object):
                     '|GlanceBackend: cinder|" ' +
                     file_path)
 
+
+            cmds.append(
+                'sed -i "s|TimeZone:.*' +
+                '|TimeZone: \\"' +
+                time_zone +
+                '\\" |" ' +
+                file_path)
 
             for cmd in cmds:
                 status = os.system(cmd)

--- a/src/pilot/deploy-overcloud.py
+++ b/src/pilot/deploy-overcloud.py
@@ -308,6 +308,10 @@ def main():
                             dest="ntp_server_fqdn",
                             default="0.centos.pool.ntp.org",
                             help="The FQDN of the ntp server to use")
+        parser.add_argument("--timezone",
+                            dest="time_zone",
+                            default="America/Chicago",
+                            help="The timezone to use")
         parser.add_argument("--timeout",
                             default="300",
                             help="The amount of time in minutes to allow the "
@@ -495,6 +499,7 @@ def main():
             swift_storage_flavor,
             block_storage_flavor,
             args.vlan_range,
+            args.time_zone,
             args.num_dell_computes,
             args.num_dell_computeshci,
             args.num_powerflex

--- a/src/pilot/templates/dell-environment.yaml
+++ b/src/pilot/templates/dell-environment.yaml
@@ -24,6 +24,9 @@ resource_registry:
 
 parameter_defaults:
 
+  # Default timezone set to CST
+  TimeZone: America/Chicago
+
   # Defines the interface to bridge onto br-ex for network nodes
   NeutronPublicInterface: bond1
   # The tenant network type for Neutron


### PR DESCRIPTION
During the deployment, timezone is not set on the overcloud nodes which can lead to inconsistency especially when it comes to ssl certificates.
This patch is for enabling the appropriate timezone which is set by default to America/Chicago but can be overwritten with a parameter within the .ini file.