### PR TITLE
Updates for NFV at Edge

### DIFF
--- a/src/deploy/jinja2_templates/neutron-ovs-dpdk-edge.j2.yaml
+++ b/src/deploy/jinja2_templates/neutron-ovs-dpdk-edge.j2.yaml
@@ -20,7 +20,6 @@ resource_registry:
 parameter_defaults:
   NeutronDatapathType: "netdev"
   NeutronVhostuserSocketDir: "/var/lib/vhost_sockets"
-  NovaSchedulerDefaultFilters: "ComputeFilter,AvailabilityZoneFilter,ComputeCapabilitiesFilter,ImagePropertiesFilter,NUMATopologyFilter"
   NeutronPluginExtensions: "qos,port_security"
   NeutronOVSFirewallDriver: openvswitch
   {%- for key, val in parameter_defaults.items() %}

--- a/src/deploy/jinja2_templates/neutron-sriov-edge.j2.yaml
+++ b/src/deploy/jinja2_templates/neutron-sriov-edge.j2.yaml
@@ -4,15 +4,27 @@ resource_registry:
   OS::TripleO::Services::NeutronSriovHostConfig: {{NeutronSriovHostConfig}}
 parameter_defaults:
   NeutronMechanismDrivers: ['sriovnicswitch', 'openvswitch']
-  NovaSchedulerDefaultFilters: ['RetryFilter','AvailabilityZoneFilter','ComputeFilter','ComputeCapabilitiesFilter','ImagePropertiesFilter','ServerGroupAntiAffinityFilter','ServerGroupAffinityFilter','PciPassthroughFilter','AggregateInstanceExtraSpecsFilter']
-  NovaSchedulerAvailableFilters: ["nova.scheduler.filters.all_filters","nova.scheduler.filters.pci_passthrough_filter.PciPassthroughFilter"]
   NeutronEnableIsolatedMetadata: true
   NeutronEnableForceMetadata: true
   NeutronTunnelTypes: ''
   NumSriovVfs: {{parameter_defaults.NumSriovVfs}}
-  NeutronPhysicalDevMappings: {{parameter_defaults.NeutronPhysicalDevMappings}}
-  NovaPCIPassthrough:
-    {%- for dev in parameter_defaults.NovaPCIPassthrough %}
-    - devname: {{dev.devname}}
-      physical_network: {{dev.physical_network}}
-    {%- endfor %}
+  {%- for key, val in parameter_defaults.items() %}
+    {%- if key.endswith("Parameters") %}
+  {{key}}:
+      {%- for _key, _val in val.items() %}
+        {%- if _key == "NeutronPhysicalDevMappings" %}
+    {{_key}}:
+          {%- for item in _val %}
+      - {{item}}
+          {%- endfor %}
+        {%- endif %}
+        {%- if _key == "NovaPCIPassthrough" %}
+    {{_key}}:
+          {%- for dev in _val %}
+      - devname: {{dev.devname}}
+        physical_network: {{dev.physical_network}}
+          {%- endfor %}
+        {%- endif %}
+      {%- endfor %}
+    {%- endif %}
+  {%- endfor %}

--- a/src/pilot/dell_nfv_edge.py
+++ b/src/pilot/dell_nfv_edge.py
@@ -90,25 +90,26 @@ class ConfigEdge(ConfigOvercloud):
             self.nfv_params.parse_data(node_data)
             self.nfv_params.get_all_cpus()
             self.nfv_params.get_host_cpus(hostos_cpu_count)
+            self.nfv_params.get_nova_cpus()
+            self.nfv_params.get_isol_cpus()
             if is_ovs_dpdk:
                 dpdk_nics = self.find_ifaces_by_keyword(nic_env_file,
                                                         'Dpdk')
                 logger.debug("DPDK-NICs >>" + str(dpdk_nics))
                 self.nfv_params.get_pmd_cpus(self.mtu, dpdk_nics)
                 self.nfv_params.get_socket_memory(self.mtu, dpdk_nics)
-            self.nfv_params.get_nova_cpus()
-            self.nfv_params.get_isol_cpus()
             kernel_args += " isolcpus={}".format(self.nfv_params.isol_cpus)
-            # dell-environmment
-            nova_cpus = self.nfv_params.nova_cpus
-            params_dell_env["NovaComputeCpuDedicatedSet"] = nova_cpus
+            # dell-environmment role specific cpu parameters
+            params_dell_env["IsolCpusList"] = self.nfv_params.isol_cpus
+            params_dell_env["NovaComputeCpuDedicatedSet"] = self.nfv_params.nova_cpus
         if is_ovs_dpdk:
             params_dpdk = params["dpdk"] = {}
             params_dpdk["OvsDpdkCoreList"] = self.nfv_params.host_cpus
-            params_dpdk["NovaComputeCpuSharedSet"] = self.nfv_params.host_cpus
             params_dpdk["OvsPmdCoreList"] = self.nfv_params.pmd_cpus
             params_dpdk["OvsDpdkSocketMemory"] = self.nfv_params.socket_mem
-            params_dpdk["IsolCpusList"] = self.nfv_params.isol_cpus
+            # params_dpdk["IsolCpusList"] = self.nfv_params.isol_cpus # Populated in dell_env file
+            # params_dpdk["NovaComputeCpuDedicatedSet"] = self.nfv_params.nova_cpus # Populated in dell_env file
+            # params_dpdk["NovaComputeCpuSharedSet"] = self.nfv_params.shared_cpus # Not used in current Architecture
 
         params_dell_env["KernelArgs"] = kernel_args
         return params


### PR DESCRIPTION
This PR tracks all the updates and improvements from consulting sessions for edge.

1- Removed Scheduling filters from edge templates. They are only applied to core controllers.
2- Relocated Cpu parameters to make them role specific for Numa and DPDK deployments.