### PR TITLE
Edge & BCM related minor changes

### DIFF
--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -3074,6 +3074,7 @@ class Director(InfraHost):
             role_params = params[role_param_k] = {}
             role_params["KernelArgs"] = dell_env_params["KernelArgs"]
             if is_numa:
+                role_params["TunedProfileName"] = "cpu-partitioning"
                 role_params["NovaComputeCpuDedicatedSet"] = dell_env_params["NovaComputeCpuDedicatedSet"]
                 role_params["IsolCpusList"] = dell_env_params["IsolCpusList"]
         return params

--- a/src/deploy/osp_deployer/settings/sample_csp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_csp_profile.ini
@@ -278,7 +278,7 @@ numa_enable=true
 ovs_dpdk_enable=false
 
 # If OVS-DPDK is enabled. Choose the appropriate driver for the NICs being used. 
-# For Intel, use "vfio-pci" and for Mellanox use "mlx5_core" 
+# For Intel and Broadcom, use "vfio-pci" and for Mellanox use "mlx5_core" 
 HostNicDriver=vfio-pci
 
 # Enter number of cores you want to reserve for Host OS

--- a/src/deploy/osp_deployer/settings/sample_hci.ini
+++ b/src/deploy/osp_deployer/settings/sample_hci.ini
@@ -278,7 +278,7 @@ numa_enable=false
 ovs_dpdk_enable=false
 
 # If OVS-DPDK is enabled. Choose the appropriate driver for the NICs being used. 
-# For Intel, use "vfio-pci" and for Mellanox use "mlx5_core" 
+# For Intel and Broadcom, use "vfio-pci" and for Mellanox use "mlx5_core" 
 HostNicDriver=vfio-pci
 
 # Enter number of cores you want to reserve for Host OS

--- a/src/deploy/osp_deployer/settings/sample_powerflex.ini
+++ b/src/deploy/osp_deployer/settings/sample_powerflex.ini
@@ -281,7 +281,7 @@ numa_enable=false
 ovs_dpdk_enable=false
 
 # If OVS-DPDK is enabled. Choose the appropriate driver for the NICs being used. 
-# For Intel, use "vfio-pci" and for Mellanox use "mlx5_core" 
+# For Intel and Broadcom, use "vfio-pci" and for Mellanox use "mlx5_core" 
 HostNicDriver=vfio-pci
 
 # Enter number of cores you want to reserve for Host OS

--- a/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
+++ b/src/deploy/osp_deployer/settings/sample_xsp_profile.ini
@@ -277,7 +277,7 @@ numa_enable=false
 ovs_dpdk_enable=false
 
 # If OVS-DPDK is enabled. Choose the appropriate driver for the NICs being used. 
-# For Intel, use "vfio-pci" and for Mellanox use "mlx5_core" 
+# For Intel and Broadcom, use "vfio-pci" and for Mellanox use "mlx5_core" 
 HostNicDriver=vfio-pci
 
 # Enter number of cores you want to reserve for Host OS


### PR DESCRIPTION
- Successfully deployed and tested **OVS-DPDK** on Broadcom with "**vfio-pci**" PMD driver (on R60)
- Minor Edge side NFV change