### PR TITLE
CES-12022 Added missing params at Edge

### DIFF
--- a/src/deploy/jinja2_templates/nic-configs/compute_edge.j2.yaml
+++ b/src/deploy/jinja2_templates/nic-configs/compute_edge.j2.yaml
@@ -296,6 +296,10 @@ resources:
                     mtu:
                       get_param: {{member.mtu}}
                     {%- endif %}
+                    {%- if "bonding_options" in member %}
+                    bonding_options:
+                      get_param: {{member.bonding_options}}
+                    {%- endif %}
                     {%- if "vlan_id" in member %}
                     vlan_id:
                       get_param: {{member.vlan_id}}


### PR DESCRIPTION
- Fixed the missing params in case of deploying Standalone SR-IOV 4 port at the Edge
- Cold Migration issue at Edge with SR-IOV is resolved.

Did multiple new SR-IOV deployments at Edge with this change, This PR is good to go.