### PR TITLE
Virt-customize changes for IceLake on RHEL 8.2

### DIFF
--- a/src/deploy/osp_deployer/director.py
+++ b/src/deploy/osp_deployer/director.py
@@ -189,8 +189,14 @@ class Director(InfraHost):
                   " --director_ip " + \
                   self.ip
 
+        if len(self.settings.overcloud_nodes_pwd) | len(self.settings.powerflex_nodes ) > 0:
+            cmd += " --sah_ip " + self.settings.sah_node.public_api_ip
+            cmd += " --sah_pwd " + self.settings.sah_node.root_password
+
         if len(self.settings.overcloud_nodes_pwd) > 0:
             cmd += " --nodes_pwd " + self.settings.overcloud_nodes_pwd
+
+
         if len(self.settings.powerflex_nodes) > 0:
             cmd += " --enable_powerflex"
         stdout, stderr, exit_status = self.run(cmd)

--- a/src/deploy/osp_deployer/sah.py
+++ b/src/deploy/osp_deployer/sah.py
@@ -290,6 +290,9 @@ class Sah(InfraHost):
             for host in hosts:
                 cmd = 'ssh-keygen -R ' + host
                 self.run(cmd)
+            # Removing authorized keys as well (if any), i.e. director node
+            cmd = 'rm -f .ssh/authorized_keys'
+            self.run(cmd)
         else:
             for host in hosts:
                 subprocess.check_output('ssh-keygen -R ' + host,


### PR DESCRIPTION
- This PR covers the alternative workaround for **Virt-customize** issue we are facing on **IceLake**, all under the same **"install-director.sh"** file
- Changes consists of SCP the overcloud image first to SAH node, customized it there and reupload the image to director node, covers powerflex nodes as well
- Tested this change with multiple deployments on **R178** (IceLake) Stamp

@gaelrehault kindly review it and let me know if you have any comments/concerns? Thanks